### PR TITLE
Request location update to Android system and fetch the actual location

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
@@ -23,7 +23,7 @@ interface MainContract {
         )
 
         fun onVibrationRequested()
-        fun onLocationUpdateRequested()
+        suspend fun onLocationUpdateRequested()
         fun onNavigationFinished()
         fun onSnackbarDisplayed()
     }
@@ -37,8 +37,8 @@ interface MainContract {
             query: String? = null
         ): List<Venue>
 
-        fun fetchLocation(): Location
-        fun fetchDrivingModelFlow(): Flow<Boolean>
+        suspend fun fetchLocation(): Location
+        fun fetchDrivingModeFlow(): Flow<Boolean>
         suspend fun enableDrivingMode(enabled: Boolean)
         suspend fun createCheckin(
             venueId: String,

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
@@ -165,7 +165,7 @@ fun MainScreen(
                     }
                 )
                 Button(
-                    onClick = { viewModel.onLocationUpdateRequested() },
+                    onClick = { coroutineScope.launch { viewModel.onLocationUpdateRequested() } },
                     enabled = viewModel.locationState.value is MainContract.LocationState.Loaded
                 ) {
                     Text(
@@ -369,7 +369,7 @@ private fun MainActivityScreenPreview() {
             override suspend fun checkIn(venueId: String, shout: String?) {}
 
             override fun onVibrationRequested() {}
-            override fun onLocationUpdateRequested() {}
+            override suspend fun onLocationUpdateRequested() {}
             override fun onNavigationFinished() {}
             override fun onSnackbarDisplayed() {}
 

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
@@ -65,7 +65,7 @@ fun MainScreen(
     viewModel: MainContract.ViewModel,
     navController: NavController
 ) {
-    var drivingModeState = viewModel.drivingModeFlow
+    val drivingModeState = viewModel.drivingModeFlow
         .collectAsState(initial = false)
 
     var shout by remember { mutableStateOf("") }


### PR DESCRIPTION
# 概要

closes #10

`MainInteractor. fetchLocation` で `FusedLocationProviderClient.requestLocationUpdates` を呼び出し、最新の位置情報を端末に格納してもらうようリクエストするような実装方法に変更しました。

これによって、他のアプリ等による端末の現在の位置情報のアップデートを待つことなく、積極的に位置情報の更新を図ることが可能になります。

なお、`FusedLocationProviderClient.locationFlow` の `first()` を呼び出すだけなので、位置情報が取得できたらすぐに `FusedLocationProviderClient.removeLocationUpdates` が呼ばれ、無駄な位置情報の要求はされないようになっているはずです。

## 動作確認

* 実端末（Google Pixel 6a）で "Update Venue list" ボタンを押下すると位置情報更新のリクエストが発生していることをログで確認