### PR TITLE
Add Gradle Managed Devices for instrumented tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         cache: 'gradle'
     - name: Run tests
       run: ./gradlew testDebug --continue
-  androitdtest:
+  androidtest:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -42,7 +42,12 @@ jobs:
         java-version: '17'
         cache: 'gradle'
     - name: Run Instrumented tests
-      run: ./gradlew pixel6api33DebugAndroidTest
+      run: | # https://github.com/android/sunflower/blob/e404b8c310d9b9199dd1d74d58072f4116d380f2/.github/workflows/android.yml#L66
+        ./gradlew pixel6api33DebugAndroidTest \
+          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" \
+          -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=20 \
+          -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true \
+          --info
     - uses: actions/upload-artifact@v3
       with:
         name: outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - main
     
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -19,5 +19,31 @@ jobs:
         cache: 'gradle'
     - name: Lint
       run: ./gradlew lintKotlin lint
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: '17'
+        cache: 'gradle'
     - name: Run tests
       run: ./gradlew testDebug --continue
+  androitdtest:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: '17'
+        cache: 'gradle'
+    - name: Run Instrumented tests
+      run: ./gradlew pixel6api33DebugAndroidTest
+    - uses: actions/upload-artifact@v3
+      with:
+        name: outputs
+        path: app/build/reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run tests
       run: ./gradlew testDebug --continue
   androidtest:
-    runs-on: ubuntu-22.04
+    runs-on: macos-12 # For virtualization support
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
         distribution: zulu
         java-version: '17'
         cache: 'gradle'
-    - name: Run Instrumented tests
+    - name: Run instrumented tests
       run: | # https://github.com/android/sunflower/blob/e404b8c310d9b9199dd1d74d58072f4116d380f2/.github/workflows/android.yml#L66
         ./gradlew pixel6api33DebugAndroidTest \
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       run: | # https://github.com/android/sunflower/blob/e404b8c310d9b9199dd1d74d58072f4116d380f2/.github/workflows/android.yml#L66
         ./gradlew pixel6api33DebugAndroidTest \
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" \
-          -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=20 \
+          -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=600 \
           -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true \
           --info
     - uses: actions/upload-artifact@v3

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -57,6 +59,14 @@ android {
         packagingOptions {
             jniLibs {
                 useLegacyPackaging true
+            }
+        }
+        managedDevices {
+            devices {
+                pixel6api33 (ManagedVirtualDevice) {
+                    device = "Pixel 6"
+                    apiLevel = 33
+                }
             }
         }
     }


### PR DESCRIPTION
# 概要

ref: https://github.com/private-yusuke/interscheckin/pull/17#issuecomment-1336360740

[Gradle Managed Devices](https://developer.android.com/studio/test/gradle-managed-devices) で CI でも Android Test（instrumented test）を走らせるようにします。

また、その結果のレポートファイルを Artifact としてアップロードするようにします。