### PR TITLE
Create `MainContract.{Venue,Checkin}` to prevent accessing to the raw API response directly

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
@@ -53,7 +53,7 @@ interface MainContract {
         val name: String,
         val categoriesString: String,
         val distance: Long?,
-        val icon: Icon
+        val icon: Icon?
     ) {
         data class Icon(
             val name: String,

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
@@ -4,7 +4,6 @@ import android.location.Location
 import android.os.VibrationEffect
 import androidx.compose.runtime.State
 import kotlinx.coroutines.flow.Flow
-import pub.yusuke.foursquareclient.models.Checkin
 
 interface MainContract {
     interface ViewModel {
@@ -61,6 +60,10 @@ interface MainContract {
             val url: String
         )
     }
+
+    data class Checkin(
+        val venueName: String
+    )
 
     sealed class LocationState {
         /**

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
@@ -5,7 +5,6 @@ import android.os.VibrationEffect
 import androidx.compose.runtime.State
 import kotlinx.coroutines.flow.Flow
 import pub.yusuke.foursquareclient.models.Checkin
-import pub.yusuke.foursquareclient.models.Venue
 
 interface MainContract {
     interface ViewModel {
@@ -48,6 +47,19 @@ interface MainContract {
         ): Checkin
 
         fun vibrate(vibrationEffect: VibrationEffect)
+    }
+
+    data class Venue(
+        val id: String,
+        val name: String,
+        val categoriesString: String,
+        val distance: Long?,
+        val icon: Icon
+    ) {
+        data class Icon(
+            val name: String,
+            val url: String
+        )
     }
 
     sealed class LocationState {

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
@@ -72,12 +72,12 @@ class MainInteractor @Inject constructor(
         shout: String,
         latitude: Double,
         longitude: Double
-    ): Checkin = foursquareCheckinsRepository.createCheckin(
+    ): MainContract.Checkin = foursquareCheckinsRepository.createCheckin(
         venueId = venueId,
         shout = shout,
         latitude = latitude,
         longitude = longitude
-    )
+    ).translateToMainContractCheckin()
 
     override fun vibrate(vibrationEffect: VibrationEffect) =
         vibratorManager.defaultVibrator.vibrate(vibrationEffect)
@@ -95,5 +95,10 @@ class MainInteractor @Inject constructor(
                 name = this.categories.first().name,
                 url = this.categories.first().icon.url()
             )
+        )
+
+    private fun Checkin.translateToMainContractCheckin(): MainContract.Checkin =
+        MainContract.Checkin(
+            venueName = this.venue.name
         )
 }

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
@@ -91,10 +91,12 @@ class MainInteractor @Inject constructor(
             name = this.name,
             categoriesString = this.categories.joinToString(", ") { it.name },
             distance = this.distance,
-            icon = MainContract.Venue.Icon(
-                name = this.categories.first().name,
-                url = this.categories.first().icon.url()
-            )
+            icon = this.categories.firstOrNull()?.let { category ->
+                MainContract.Venue.Icon(
+                    name = category.name,
+                    url = category.icon.url()
+                )
+            }
         )
 
     private fun Checkin.translateToMainContractCheckin(): MainContract.Checkin =

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
@@ -50,13 +50,6 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberAsyncImagePainter
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-import pub.yusuke.foursquareclient.models.Category
-import pub.yusuke.foursquareclient.models.Geocodes
-import pub.yusuke.foursquareclient.models.Icon
-import pub.yusuke.foursquareclient.models.LatAndLong
-import pub.yusuke.foursquareclient.models.Location
-import pub.yusuke.foursquareclient.models.Venue
-import pub.yusuke.foursquareclient.models.url
 import pub.yusuke.fusedlocationktx.toFormattedString
 import pub.yusuke.interscheckin.R
 import pub.yusuke.interscheckin.ui.theme.InterscheckinTheme
@@ -213,7 +206,7 @@ fun MainScreen(
 
 @Composable
 fun VenueColumn(
-    venues: List<Venue>,
+    venues: List<MainContract.Venue>,
     selectedVenueIdState: String,
     onClickVenue: (String) -> Unit,
     onLongClickVenue: (String) -> Unit
@@ -221,7 +214,7 @@ fun VenueColumn(
     LazyColumn {
         items(venues) { venue ->
             VenueRow(
-                selected = venue.fsq_id == selectedVenueIdState,
+                selected = venue.id == selectedVenueIdState,
                 onClick = onClickVenue,
                 onLongClick = onLongClickVenue,
                 venue = venue
@@ -279,7 +272,7 @@ fun VenueRow(
     selected: Boolean,
     onClick: (String) -> Unit,
     onLongClick: (String) -> Unit,
-    venue: Venue
+    venue: MainContract.Venue
 ) {
     Box {
         Box(
@@ -294,24 +287,24 @@ fun VenueRow(
                 .fillMaxWidth()
                 .padding(4.dp)
                 .combinedClickable(
-                    onClick = { onClick.invoke(venue.fsq_id) },
-                    onLongClick = { onLongClick.invoke(venue.fsq_id) }
+                    onClick = { onClick.invoke(venue.id) },
+                    onLongClick = { onLongClick.invoke(venue.id) }
                 )
         ) {
-            if (venue.categories.isEmpty()) {
+            if (venue.categoriesString.isEmpty()) {
                 Text("no icon")
             } else {
                 Image(
-                    painter = rememberAsyncImagePainter(venue.categories.first().icon.url()),
-                    contentDescription = venue.categories.first().name,
+                    painter = rememberAsyncImagePainter(venue.icon.url),
+                    contentDescription = venue.icon.name,
                     modifier = Modifier.size(32.dp)
                 )
             }
             Column {
                 Row {
-                    Text("${venue.name} (${venue.distance} m)")
+                    Text("${venue.name} (${venue.distance ?: "?"} m)")
                 }
-                Text(venue.categories.joinToString(", ") { it.name })
+                Text(venue.categoriesString)
                 if (selected) {
                     Text(
                         modifier = Modifier
@@ -325,39 +318,15 @@ fun VenueRow(
 }
 
 private val previewVenue =
-    Venue(
-        categories = listOf(
-            Category(
-                id = "testCategoryId",
-                name = "testCategory",
-                icon = Icon("prefix", "suffix")
-            )
-        ),
-        chains = listOf(),
-        distance = -1,
-        fsq_id = "fsq_id",
-        geocodes = Geocodes(
-            LatAndLong(
-                latitude = 0.0,
-                longitude = 0.0
-            )
-        ),
-        link = "https://example.com/",
-        location = Location(
-            address = "210 S King St",
-            address_extended = null,
-            census_block = "511076105052013",
-            country = "US",
-            cross_street = null,
-            dma = "Washington, Dc-Hagrstwn",
-            formatted_address = "210 S King St, Leesburg, VA 20175",
-            locality = "Leesburg",
-            postcode = "20175",
-            region = "バージニア州"
-        ),
-        name = "Black Walnut Brewery",
-        related_places = null,
-        timezone = "America/New_York"
+    MainContract.Venue(
+        id = "id",
+        name = "test venue",
+        categoriesString = "test category, test category 2",
+        distance = 12,
+        icon = MainContract.Venue.Icon(
+            name = "test category",
+            url = "https://example.com/foo.png"
+        )
     )
 
 @SuppressLint("UnrememberedMutableState")

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
@@ -115,8 +115,8 @@ fun MainScreen(
                     Button(
                         onClick = { coroutineScope.launch { viewModel.checkIn(selectedVenueIdState) } },
                         enabled = viewModel.locationState.value is MainContract.LocationState.Loaded &&
-                                viewModel.checkinState.value !is MainContract.CheckinState.Loading &&
-                                selectedVenueIdState != "",
+                            viewModel.checkinState.value !is MainContract.CheckinState.Loading &&
+                            selectedVenueIdState != "",
                         modifier = Modifier
                             .semantics { contentDescription = "Create a Checkin" }
                     ) {
@@ -291,7 +291,7 @@ fun VenueRow(
                     onLongClick = { onLongClick.invoke(venue.id) }
                 )
         ) {
-            if (venue.categoriesString.isEmpty()) {
+            if (venue.icon == null) {
                 Text("no icon")
             } else {
                 Image(

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
@@ -115,8 +115,8 @@ fun MainScreen(
                     Button(
                         onClick = { coroutineScope.launch { viewModel.checkIn(selectedVenueIdState) } },
                         enabled = viewModel.locationState.value is MainContract.LocationState.Loaded &&
-                            viewModel.checkinState.value !is MainContract.CheckinState.Loading &&
-                            selectedVenueIdState != "",
+                                viewModel.checkinState.value !is MainContract.CheckinState.Loading &&
+                                selectedVenueIdState != "",
                         modifier = Modifier
                             .semantics { contentDescription = "Create a Checkin" }
                     ) {
@@ -157,7 +157,7 @@ fun MainScreen(
                         is MainContract.CheckinState.Idle ->
                             stringResource(
                                 R.string.main_message_checkin_success,
-                                it.lastCheckin.venue.name
+                                it.lastCheckin.venueName
                             )
                         is MainContract.CheckinState.Error ->
                             "Error: ${it.throwable.message}\n${it.throwable.stackTrace}"

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainViewModel.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import pub.yusuke.foursquareclient.FoursquareClient
 import pub.yusuke.foursquareclient.FoursquareClientImpl
-import pub.yusuke.foursquareclient.models.Checkin
 import pub.yusuke.interscheckin.R
 import javax.inject.Inject
 
@@ -136,7 +135,7 @@ class MainViewModel @Inject constructor(
         shout: String,
         latitude: Double,
         longitude: Double
-    ): Checkin =
+    ): MainContract.Checkin =
         interactor.createCheckin(
             venueId = venueId,
             shout = shout,

--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Venue.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Venue.kt
@@ -1,11 +1,9 @@
 package pub.yusuke.foursquareclient.models
 
-import android.location.LocationManager
-
 data class Venue(
     val categories: List<Category>,
     val chains: List<Chain>?,
-    val distance: Int?,
+    val distance: Long?,
     val fsq_id: String,
     val geocodes: Geocodes,
     val link: String?,
@@ -57,10 +55,6 @@ data class LatAndLong(
 )
 
 fun LatAndLong.llString() = "${latitude.toBigDecimal().toPlainString()},${longitude.toBigDecimal().toPlainString()}"
-fun LatAndLong.toLocation() = android.location.Location(LocationManager.GPS_PROVIDER).apply {
-    latitude = this@toLocation.latitude
-    longitude = this@toLocation.longitude
-}
 
 data class Parent(
     val fsq_id: String,


### PR DESCRIPTION
# 概要

`MainScreen` および `MainViewModel` で API client が返してきた生のレスポンスに近いデータ構造を直接触れないようにするために `MainContract.Venue` と `MainContract.Checkin` を定義します。