### PR TITLE
Fix shout text being not used

### DIFF
--- a/app/src/androidTest/java/pub/yusuke/interscheckin/repositories/foursquarecheckins/FakeFoursquareCheckinsRepository.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/repositories/foursquarecheckins/FakeFoursquareCheckinsRepository.kt
@@ -13,7 +13,7 @@ class FakeFoursquareCheckinsRepository @Inject constructor() : FoursquareCheckin
         longitude: Double
     ): Checkin =
         Checkin(
-            id = venueId,
+            id = "checkin_id",
             shout = shout,
             createdAt = 100,
             type = "checkin",
@@ -24,6 +24,7 @@ class FakeFoursquareCheckinsRepository @Inject constructor() : FoursquareCheckin
                 total = 1
             ),
             venue = V3Venue(
+                id = venueId,
                 name = "good venue"
             )
         )

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/util/MainScreenTestData.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/util/MainScreenTestData.kt
@@ -1,0 +1,26 @@
+package pub.yusuke.interscheckin.ui.main.util
+
+import android.location.Location
+import pub.yusuke.interscheckin.ui.main.MainContract
+
+object MainScreenTestData {
+    val venue =
+        MainContract.Venue(
+            id = "abc",
+            name = "test venue",
+            categoriesString = "test categories",
+            distance = 1,
+            icon = MainContract.Venue.Icon(
+                name = "icon name",
+                url = "https://example.com/test.icon"
+            )
+        )
+
+    val venuesStateIdle = MainContract.VenuesState.Idle(listOf(venue))
+    val venuesStateLoading = MainContract.VenuesState.Loading(emptyList())
+
+    val location = Location("")
+
+    val locationStateLoaded = MainContract.LocationState.Loaded(location)
+    val locationStateLoading = MainContract.LocationState.Loading(null)
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
@@ -62,7 +62,9 @@ interface MainContract {
     }
 
     data class Checkin(
-        val venueName: String
+        val id: String,
+        val venueName: String,
+        val shout: String?
     )
 
     sealed class LocationState {

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
@@ -95,6 +95,8 @@ class MainInteractor @Inject constructor(
 
     private fun Checkin.translateToMainContractCheckin(): MainContract.Checkin =
         MainContract.Checkin(
-            venueName = this.venue.name
+            id = this.venue.id,
+            venueName = this.venue.name,
+            shout = this.shout
         )
 }

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
@@ -88,7 +88,10 @@ fun MainScreen(
                         .fillMaxWidth(),
                     onLongClickVenue = { venueId ->
                         viewModel.onVibrationRequested()
-                        coroutineScope.launch { viewModel.checkIn(venueId) }
+                        coroutineScope.launch {
+                            viewModel.checkIn(venueId, shout)
+                            shout = ""
+                        }
                     }
                 )
                 Text(
@@ -106,19 +109,25 @@ fun MainScreen(
                     value = shout,
                     onValueChange = { shout = it },
                     modifier = Modifier
-                        .height(150.dp),
+                        .height(150.dp)
+                        .semantics { contentDescription = "TextField for shout" },
                     placeholder = { Text(stringResource(R.string.main_shout_placeholder)) }
                 )
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Button(
-                        onClick = { coroutineScope.launch { viewModel.checkIn(selectedVenueIdState) } },
+                        onClick = {
+                            coroutineScope.launch {
+                                viewModel.checkIn(selectedVenueIdState, shout)
+                                shout = ""
+                            }
+                        },
                         enabled = viewModel.locationState.value is MainContract.LocationState.Loaded &&
                             viewModel.checkinState.value !is MainContract.CheckinState.Loading &&
                             selectedVenueIdState != "",
                         modifier = Modifier
-                            .semantics { contentDescription = "Create a Checkin" }
+                            .semantics { contentDescription = "Button for creating a Checkin" }
                     ) {
                         Text(stringResource(R.string.main_button_checkin))
                     }

--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Checkin.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Checkin.kt
@@ -15,6 +15,7 @@ data class Checkin(
 )
 
 data class V3Venue(
+    val id: String,
     val name: String
 )
 


### PR DESCRIPTION
# 概要

closes #15 

shout（チェックインのコメント）を入力してチェックインしても、そのチェックインに shout が付いていなかったり、その入力欄にある shout が消費されていなかった問題を修正します。

また、それを確認するための instrumented test を追加します。