### PR TITLE
Fix crashing while trying to create a checkin while updating list of Venues

### DIFF
--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/util/MainScreenTestData.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/util/MainScreenTestData.kt
@@ -17,10 +17,10 @@ object MainScreenTestData {
         )
 
     val venuesStateIdle = MainContract.VenuesState.Idle(listOf(venue))
-    val venuesStateLoading = MainContract.VenuesState.Loading(emptyList())
+    val venuesStateLoading = MainContract.VenuesState.Loading(listOf(venue))
 
     val location = Location("")
 
     val locationStateLoaded = MainContract.LocationState.Loaded(location)
-    val locationStateLoading = MainContract.LocationState.Loading(null)
+    val locationStateLoading = MainContract.LocationState.Loading(location)
 }


### PR DESCRIPTION
# 概要

closes #16

Venue 一覧を更新中にチェックインしようとするとクラッシュするバグを修正します。

また、その操作を再現するための instrumeted test を追加します。