### PR TITLE
Remove dependency `org.mockito:mockito-core:4.9.0`

### DIFF
--- a/library/foursquare-client/build.gradle
+++ b/library/foursquare-client/build.gradle
@@ -49,7 +49,6 @@ dependencies {
 
     implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
 
-    testImplementation 'org.mockito:mockito-core:4.9.0'
     androidTestImplementation "androidx.test.ext:junit:$androidx_junit_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_core_version"
 }


### PR DESCRIPTION
# 概要

closes #27

foursquare-client で一時期テストを書こうと思って Mockito を入れていたが、実際には利用していないし、これからテストを書くにしても `:app` と揃えて MockK を使うことになると考えられる。

そのため、foursquare-client が持つ `org.mockito:mockito-core:4.9.0` への依存を削除します。