### PR TITLE
Always upload test reports as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true \
           --info
     - uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: outputs
         path: app/build/reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: outputs
+        name: test-reports
         path: app/build/reports/


### PR DESCRIPTION
# 概要

https://github.com/private-yusuke/interscheckin/commit/6351da7076bdfff977e2b2de2ae09c808c1b4fe5 が落ちているのを見つけたとき、テストが落ちていてもテストレポートは生成されていることがしばしば期待される。その場合はテストレポートが欲しい。そこで、いつでも artifact として `/app/build/reports` 以下がアップロードされるように修正します。

余談：なぜ当該 commit で落ちたのだろうか……ローカルでは落ちないのだが