### PR TITLE
Fix the scrollable area of HistoriesScreen being narrow

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreen.kt
@@ -115,7 +115,9 @@ private fun HistoriesContent(
             start = 12.dp,
             end = 12.dp
         ),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
     ) {
         items(lazyPagingItems) {
             it?.let { checkin ->


### PR DESCRIPTION
# 概要

#34 で追加した画面をスクロールする際に何も表示されていない箇所でスクロールすることができなかったのを修正します。