### PR TITLE
Upload only the APK as an artifact

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -22,5 +22,5 @@ jobs:
       run: ./gradlew assembleRelease
     - uses: actions/upload-artifact@v3
       with:
-        name: outputs
-        path: app/build/outputs/
+        name: Interscheckin-${{ github.sha }}.apk
+        path: app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
# 概要

Actions タブから APK をダウンロードして端末にインストールしたいとき、わざわざ zip ファイルを解凍しなければいけないのは面倒なので、APK が artifact としてそのままアップロードされるようにします。