### PR TITLE
Fix HistoriesScreen pagination

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesViewModel.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesViewModel.kt
@@ -22,7 +22,7 @@ class HistoriesViewModel @Inject constructor(
         Pager(
             config = PagingConfig(
                 pageSize = PAGE_SIZE,
-                initialLoadSize = PAGE_SIZE * 3
+                initialLoadSize = INITIAL_LOAD_SIZE
             ),
             initialKey = null,
             pagingSourceFactory = {
@@ -31,6 +31,7 @@ class HistoriesViewModel @Inject constructor(
         ).flow.cachedIn(viewModelScope)
 
     companion object {
-        private const val PAGE_SIZE = 20
+        private const val PAGE_SIZE = 50
+        private const val INITIAL_LOAD_SIZE = 100
     }
 }

--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/FoursquareClientImpl.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/FoursquareClientImpl.kt
@@ -200,6 +200,7 @@ class FoursquareClientImpl(
             checkinApiService.getCheckinHistories(
                 userId = userId?.toString() ?: "self",
                 offset = offset,
+                limit = limit,
                 beforeTimestamp = beforeTimestamp,
                 oauthToken = oauth_token,
                 authorization = api_key

--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/network/CheckinApiService.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/network/CheckinApiService.kt
@@ -53,6 +53,8 @@ interface CheckinApiService {
         beforeTimestamp: Long? = null,
         @Query("offset")
         offset: Long? = null,
+        @Query("limit")
+        limit: Long? = null,
         @Query("oauth_token")
         oauthToken: String,
         @Query("v")


### PR DESCRIPTION
# 概要

closes #37

`HistoriesScreen` のページネーションがうまく動いていなかった問題を修正します。