### PR TITLE
Add instrumented tests for `HistoriesScreen`

### DIFF
--- a/app/src/androidTest/java/pub/yusuke/interscheckin/repositories/foursquarecheckins/FakeFoursquareCheckinsRepository.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/repositories/foursquarecheckins/FakeFoursquareCheckinsRepository.kt
@@ -4,6 +4,28 @@ import pub.yusuke.foursquareclient.models.Checkin
 import javax.inject.Inject
 
 class FakeFoursquareCheckinsRepository @Inject constructor() : FoursquareCheckinsRepository {
+    private val exampleVenue = Checkin.V2Venue(
+        id = "venue_id",
+        name = "good venue",
+        location = Checkin.V2Venue.Location(
+            state = "茨城県",
+            city = "つくば市"
+        ),
+        categories = listOf(
+            Checkin.V2Venue.Category(
+                id = "category_id",
+                name = "Intersection",
+                pluralName = "Intersections",
+                shortName = "Intersection",
+                icon = Checkin.V2Venue.Category.Icon(
+                    prefix = "https://example.com/",
+                    suffix = "foo.png"
+                ),
+                primary = true
+            )
+        )
+    )
+
     private val exampleCheckin = Checkin(
         id = "checkin_id",
         shout = "hey",
@@ -15,27 +37,7 @@ class FakeFoursquareCheckinsRepository @Inject constructor() : FoursquareCheckin
         score = Checkin.Score(
             total = 1
         ),
-        venue = Checkin.V2Venue(
-            id = "venue_id",
-            name = "good venue",
-            location = Checkin.V2Venue.Location(
-                state = "茨城県",
-                city = "つくば市"
-            ),
-            categories = listOf(
-                Checkin.V2Venue.Category(
-                    id = "category_id",
-                    name = "Intersection",
-                    pluralName = "Intersections",
-                    shortName = "Intersection",
-                    icon = Checkin.V2Venue.Category.Icon(
-                        prefix = "https://example.com/",
-                        suffix = "foo.png"
-                    ),
-                    primary = true
-                )
-            )
-        )
+        venue = exampleVenue
     )
 
     override suspend fun createCheckin(
@@ -56,5 +58,11 @@ class FakeFoursquareCheckinsRepository @Inject constructor() : FoursquareCheckin
         beforeTimestamp: Long?,
         limit: Long?
     ): List<Checkin> =
-        listOf(exampleCheckin)
+        MutableList(100) { n ->
+            exampleCheckin.copy(
+                venue = exampleVenue.copy(
+                    name = "test venue $n"
+                )
+            )
+        }
 }

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/FakeHistoriesViewModelModule.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/FakeHistoriesViewModelModule.kt
@@ -1,0 +1,26 @@
+package pub.yusuke.interscheckin.ui.histories
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import io.mockk.spyk
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [HistoriesViewModelModule::class]
+)
+interface FakeHistoriesViewModelModule {
+    @Binds
+    fun bindPaging(paging: HistoriesPaging): HistoriesContract.Paging
+
+    companion object {
+        @Provides
+        fun provideViewModel(
+            paging: HistoriesContract.Paging
+        ): HistoriesContract.ViewModel = spyk(HistoriesViewModel(SavedStateHandle(), paging))
+    }
+}

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreenTest.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreenTest.kt
@@ -1,0 +1,62 @@
+package pub.yusuke.interscheckin.ui.histories
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.navigation.NavController
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
+import androidx.paging.PagingData
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit4.MockKRule
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import javax.inject.Inject
+
+@HiltAndroidTest
+class HistoriesScreenTest {
+    val mockkRule = MockKRule(this)
+    val hiltRule = HiltAndroidRule(this)
+    val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val uiTestRule = RuleChain
+        .outerRule(mockkRule)
+        .around(hiltRule)
+        .around(composeTestRule)
+
+    @Inject
+    lateinit var vm: HistoriesContract.ViewModel
+
+    @MockK
+    lateinit var navController: NavController
+
+    /**
+     * See also [FakeHistoriesViewModelModule] for initial setup
+     */
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun `A check-in with a venue is displayed on the screen`() {
+        composeTestRule.setContent {
+            HistoriesScreen(
+                viewModel = vm,
+                navController = navController
+            )
+        }
+
+        composeTestRule
+            .onAllNodesWithText("test venue 1")
+            .assertCountEquals(1)
+    }
+}

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreenTest.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreenTest.kt
@@ -59,4 +59,30 @@ class HistoriesScreenTest {
             .onAllNodesWithText("test venue 1")
             .assertCountEquals(1)
     }
+
+    @Test
+    fun `Display _No Histories Found_ when no check-in history is found`() {
+        // given (that no histories are available)
+        every { vm.checkinsFlow } returns flowOf(
+            PagingData.empty(
+                LoadStates(
+                    LoadState.NotLoading(true),
+                    LoadState.NotLoading(true),
+                    LoadState.NotLoading(true)
+                )
+            )
+        )
+
+        composeTestRule.setContent {
+            HistoriesScreen(
+                viewModel = vm,
+                navController = navController
+            )
+        }
+
+        // then
+        composeTestRule
+            .onNodeWithContentDescription("No histories found")
+            .assertExists()
+    }
 }

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/util/HistoriesScreenTestData.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/util/HistoriesScreenTestData.kt
@@ -1,0 +1,33 @@
+package pub.yusuke.interscheckin.ui.histories.util
+
+import pub.yusuke.interscheckin.ui.histories.HistoriesContract
+
+object HistoriesScreenTestData {
+    val venue =
+        HistoriesContract.Checkin.Venue(
+            id = "abc",
+            name = "test venue",
+            categoriesString = "test categories",
+            address = "Ibaraki, Tsukuba-shi",
+            icon = HistoriesContract.Checkin.Venue.Icon(
+                name = "icon name",
+                url = "https://example.com/test.icon"
+            )
+        )
+
+    val checkin = HistoriesContract.Checkin(
+        id = "def",
+        shout = "最高！",
+        createdAt = 1672841580,
+        venue = venue,
+        score = 200
+    )
+
+    val checkins: List<HistoriesContract.Checkin> = MutableList(10) { n ->
+        checkin.copy(
+            venue = venue.copy(
+                name = "test venue $n"
+            )
+        )
+    }
+}

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/FakeMainViewModelModule.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/FakeMainViewModelModule.kt
@@ -1,9 +1,18 @@
 package pub.yusuke.interscheckin.ui.main
 
+import android.os.VibratorManager
+import androidx.compose.runtime.mutableStateOf
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import pub.yusuke.interscheckin.ui.main.util.MainScreenTestData
 
 @Module
 @TestInstallIn(
@@ -13,4 +22,45 @@ import dagger.hilt.testing.TestInstallIn
 interface FakeMainViewModelModule {
     @Binds
     fun bindInteractor(interactor: MainInteractor): MainContract.Interactor
+
+    companion object {
+        @Provides
+        fun provideViewModel(
+            interactor: MainContract.Interactor
+        ): MainContract.ViewModel {
+            val vm = spyk(MainViewModel(interactor))
+
+            // Defaults to both the location and the venues loaded
+            every { vm.locationState } returns mutableStateOf(MainScreenTestData.locationStateLoaded)
+            every { vm.venuesState } returns mutableStateOf(MainScreenTestData.venuesStateIdle)
+
+            return vm
+        }
+
+        @Provides
+        fun provideVibratorManager(): VibratorManager {
+            val vibratorManager: VibratorManager = mockk()
+            every { vibratorManager.defaultVibrator } returns mockk(relaxUnitFun = true)
+
+            return vibratorManager
+        }
+
+        @Provides
+        fun provideFusedLocationProviderClient(): FusedLocationProviderClient {
+            val fusedLocationProviderClient: FusedLocationProviderClient = mockk()
+
+            every {
+                fusedLocationProviderClient.requestLocationUpdates(
+                    any(),
+                    any<LocationCallback>(),
+                    any()
+                )
+            } returns mockk()
+            every {
+                fusedLocationProviderClient.removeLocationUpdates(any<LocationCallback>())
+            } returns mockk()
+
+            return fusedLocationProviderClient
+        }
+    }
 }

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/MainScreenTest.kt
@@ -1,6 +1,5 @@
 package pub.yusuke.interscheckin.ui.main
 
-import android.os.Vibrator
 import android.os.VibratorManager
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -15,21 +14,12 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.navigation.NavController
 import com.google.android.gms.location.FusedLocationProviderClient
-import com.google.android.gms.location.LocationCallback
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.components.SingletonComponent
-import io.mockk.MockKAnnotations
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
-import io.mockk.mockk
-import io.mockk.spyk
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -49,53 +39,24 @@ class MainScreenTest {
         .around(hiltRule)
         .around(composeTestRule)
 
-    @Module
-    @InstallIn(SingletonComponent::class)
-    object MainScreenTestModule {
-        @Provides
-        fun provideViewModel(
-            interactor: MainContract.Interactor
-        ): MainContract.ViewModel = spyk(MainViewModel(interactor))
-    }
-
     @Inject
     lateinit var vm: MainContract.ViewModel
 
     @MockK
     lateinit var navController: NavController
 
-    @MockK(relaxUnitFun = true)
-    lateinit var vibrator: Vibrator
-
-    @BindValue
-    @MockK
+    @Inject
     lateinit var vibratorManager: VibratorManager
 
-    @BindValue
-    @MockK
+    @Inject
     lateinit var fusedLocationProviderClient: FusedLocationProviderClient
 
+    /**
+     * See also [FakeMainViewModelModule] for initial setup
+     */
     @Before
     fun init() {
-        MockKAnnotations.init()
         hiltRule.inject()
-
-        every { vibratorManager.defaultVibrator } returns vibrator
-
-        every {
-            fusedLocationProviderClient.requestLocationUpdates(
-                any(),
-                any<LocationCallback>(),
-                any()
-            )
-        } returns mockk()
-        every {
-            fusedLocationProviderClient.removeLocationUpdates(any<LocationCallback>())
-        } returns mockk()
-
-        // Defaults to both the location and the venues loaded
-        every { vm.locationState } returns mutableStateOf(MainScreenTestData.locationStateLoaded)
-        every { vm.venuesState } returns mutableStateOf(MainScreenTestData.venuesStateIdle)
     }
 
     @Test

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -93,9 +95,21 @@ fun HistoriesScreen(
                             )
                         }
                         is LoadState.NotLoading -> {
-                            HistoriesContent(
-                                lazyPagingItems = lazyPagingItems
-                            )
+                            if (lazyPagingItems.itemCount == 0) {
+                                Box(
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.histories_no_histories_found),
+                                        modifier = Modifier
+                                            .semantics { contentDescription = "No histories found" }
+                                    )
+                                }
+                            } else {
+                                HistoriesContent(
+                                    lazyPagingItems = lazyPagingItems
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -21,4 +21,5 @@
     <string name="main_venue_selected">選択中</string>
     <string name="histories_topbar_title">履歴</string>
     <string name="main_button_histories">履歴一覧</string>
+    <string name="histories_no_histories_found">履歴はありません</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,5 @@
 
     <!-- HistoriesScreen -->
     <string name="histories_topbar_title">Histories</string>
+    <string name="histories_no_histories_found">No histories found</string>
 </resources>


### PR DESCRIPTION
# 概要

#34 の後続 PR の一つ

この画面に履歴が表示されていることや、履歴が存在しない場合の挙動を確認するための instrumented test を追加します。