### PR TITLE
Build AndroidTest APK instead of running flaky instrumented tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,25 +31,52 @@ jobs:
         cache: 'gradle'
     - name: Run tests
       run: ./gradlew testDebug --continue
-  androidtest:
-    runs-on: macos-12 # For virtualization support
+  assemble:
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        distribution: zulu
-        java-version: '17'
-        cache: 'gradle'
-    - name: Run instrumented tests
-      run: | # https://github.com/android/sunflower/blob/e404b8c310d9b9199dd1d74d58072f4116d380f2/.github/workflows/android.yml#L66
-        ./gradlew pixel6api33DebugAndroidTest \
-          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" \
-          -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=600 \
-          -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true \
-          --info
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: test-reports
-        path: app/build/reports/
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: '17'
+          cache: 'gradle'
+      - name: Build APK
+        run: ./gradlew assemble
+  assembleDebugAndroidTest:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: '17'
+          cache: 'gradle'
+      - name: Build AndroidTest APK
+        run: ./gradlew assembleDebugAndroidTest
+
+# Temporarily commented out because of the flakiness of the executions
+# of instrumented tests on x86_64 devices.
+#  androidtest:
+#    runs-on: macos-12 # For virtualization support
+#    timeout-minutes: 30
+#    steps:
+#    - uses: actions/checkout@v3
+#    - uses: actions/setup-java@v3
+#      with:
+#        distribution: zulu
+#        java-version: '17'
+#        cache: 'gradle'
+#    - name: Run instrumented tests
+#      run: | # https://github.com/android/sunflower/blob/e404b8c310d9b9199dd1d74d58072f4116d380f2/.github/workflows/android.yml#L66
+#        ./gradlew pixel6api33DebugAndroidTest \
+#          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" \
+#          -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=600 \
+#          -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true \
+#          --info
+#    - uses: actions/upload-artifact@v3
+#      if: always()
+#      with:
+#        name: test-reports
+#        path: app/build/reports/


### PR DESCRIPTION
# 概要

related #32

CI で instrumented test を走らせると flaky である問題が以前からあったが、ここ最近になって流石に不安定すぎると感じた[^1]ため、一時的に CI では APK と instrumented test のビルドができることのみを確認するようにします。

[^1]: https://github.com/private-yusuke/interscheckin/actions/runs/3839065784 では 12 回目の試行でやっと instrumented test が成功した