### PR TITLE
Bump up Kotlin to 1.8.0 and Compose Compiler to 1.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerExtensionVersion '1.4.0'
     }
     packagingOptions {
         resources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = '1.7.20'
+        kotlin_version = '1.8.0'
         hilt_version = '2.44.2'
         compose_nav_version = '2.5.3'
         datastore_preferences_version = '1.0.0'


### PR DESCRIPTION
# 概要

closes #2

使用する Kotlin のバージョンを 1.8.0 に上げ、これと互換性のある Compose Compiler v1.4.0 を使うようにします。

## 動作確認

* ローカルで `./gradlew clean pixel6api33DebugAndroidTest` が成功する
* debug ビルドが Pixel 6a で起動できる