### PR TITLE
Disable creating PRs on `kotlin_version` by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^org.jetbrains.kotlin"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
# 概要

ref: #58

Kotlin のバージョンと Compose Compiler のバージョンは、#55 のように同時にバージョンを上げる必要がある。このため、`org.jetbrains.kotlin` から始まるパッケージについては自動的にアップデート用の PR を作成しないようにします。

## 参考にしたページ

https://docs.renovatebot.com/configuration-options/#enabled

## 動作確認

`$ npx --package=renovate -c renovate-config-validator` が成功する