### PR TITLE
Disable running `assembleDebugAndroidTest` with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,18 +43,6 @@ jobs:
           cache: 'gradle'
       - name: Build APK
         run: ./gradlew assemble
-  assembleDebugAndroidTest:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: '17'
-          cache: 'gradle'
-      - name: Build AndroidTest APK
-        run: ./gradlew assembleDebugAndroidTest
   androidtest:
     runs-on: [self-hosted, androidtest, pixel3axl, apilevel32]
     timeout-minutes: 30


### PR DESCRIPTION
# 概要

related: #69, #32

GitHub Actions を用いる自動テストから `assembleDebugAndroidTest` ジョブを削除します。

## 背景

`assembleDebugAndroidTest` は instrumented test を実行するための APK を作る task であり、これを実行する GitHub Actions ジョブ `assembleDebugAndroidTest` を #43 で追加した。しかし、#69 でタスク `connectedAndroidTest` が安定して実行できるようになった。このタスクとタスク `assembleDebugAndroidTest` は タスク `packageDebugAndroidTest` を依存に持つ。 したがって、今はもうタスク `assembleDebugAndroidTest` のみを実行するジョブは不要となっている。