### PR TITLE
Bump up Kotlin to 1.8.10 and Compose Compiler to 1.4.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.3'
     }
     packagingOptions {
         resources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = '1.8.0'
+        kotlin_version = '1.8.10'
         hilt_version = '2.45'
         compose_nav_version = '2.5.3'
         datastore_preferences_version = '1.0.0'


### PR DESCRIPTION
# 概要

Kotlin 1.8.10 および Compose Compiler 1.4.3 を使うようにします。