### PR TITLE
Bump up AGP to 8.0.0-beta04

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+        resConfigs 'en', 'ja'
 
-        resConfigs "en", "ja"
 
         javaCompileOptions {
             annotationProcessorOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
+    id 'com.android.application' version '8.0.0-beta04' apply false
+    id 'com.android.library' version '8.0.0-beta04' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false


### PR DESCRIPTION
# 概要

AGP のバージョンを `8.0.0-beta04` に上げます。
