### PR TITLE
Aggregate Kotlin and Compose Compiler updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,16 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["^org.jetbrains.kotlin"],
-      "enabled": false
+      "matchPackagePatterns": ["org.jetbrains.kotlin.*"],
+      "groupName": "kotlin"
+    },
+    {
+      "matchPackagePatterns": ["androidx.compose.compiler:compiler"],
+      "groupName": "kotlin"
+    },
+    {
+      "matchPackagePatterns": ["com.google.devtools.ksp"],
+      "groupName": "kotlin"
     },
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
# 概要

closes #84

Renovate で Kotlin と Compose Compiler のアップデートをする際に単一の PR で行うようにします。

https://medium.com/androiddevelopers/automating-dependency-updates-in-a-compose-project-168ef5e89ac5 を参考にして設定を追加しました。