### PR TITLE
Fix linting tasks in `build_apk.yml`

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -15,7 +15,7 @@ jobs:
         java-version: '17'
         cache: 'gradle'
     - name: Lint
-      run: ./gradlew lintKotlin lint
+      run: ./gradlew detekt lint
     - name: Run tests
       run: ./gradlew testDebug --continue
     - name: Build


### PR DESCRIPTION
# 概要

#91 で導入した Detekt を `build_apk.yml` 内でも用いるようにします。