### PR TITLE
Fix broken `MainScreen` layout

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -85,7 +84,7 @@ fun MainScreen(
         ) { innerPadding ->
             Column(
                 modifier = Modifier
-                    .fillMaxSize()
+                    .fillMaxWidth()
                     .padding(innerPadding),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -102,6 +101,8 @@ fun MainScreen(
                             shout = ""
                         }
                     },
+                    modifier = Modifier
+                        .height(220.dp),
                 )
                 Text(
                     text = when (val it = locationState) {


### PR DESCRIPTION
# 概要

closes #93

`MainScreen` のレイアウト崩れを修正するために `VenueList` に高さの制約を加えます。