### PR TITLE
Add `LocationAccessAcquirementScreen`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,4 +132,7 @@ dependencies {
 
     // Immutable collections for Composable functions
     implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
+
+    // Requesting the permission for location access within screens written with Jetpack Compose
+    implementation "com.google.accompanist:accompanist-permissions:0.30.0"
 }

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/FakeMainApplicationModule.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/FakeMainApplicationModule.kt
@@ -9,6 +9,8 @@ import pub.yusuke.interscheckin.repositories.foursquarecheckins.FakeFoursquareCh
 import pub.yusuke.interscheckin.repositories.foursquarecheckins.FakeFoursquarePlacesRepository
 import pub.yusuke.interscheckin.repositories.foursquarecheckins.FoursquareCheckinsRepository
 import pub.yusuke.interscheckin.repositories.foursquarecheckins.FoursquarePlacesRepository
+import pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce.LocationAccessAcquirementScreenDisplayedOnceRepository
+import pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce.LocationAccessAcquirementScreenDisplayedOnceRepositoryImpl
 import pub.yusuke.interscheckin.repositories.settings.FakeSettingsRepository
 import pub.yusuke.interscheckin.repositories.settings.SettingsRepository
 import pub.yusuke.interscheckin.repositories.userpreferences.FakeUserPreferencesRepository
@@ -49,4 +51,10 @@ interface FakeMainApplicationModule {
     fun bindVisitedVenueDao(
         visitedVenueDao: FakeVisitedVenueDao,
     ): VisitedVenueDao
+
+    @Singleton
+    @Binds
+    fun bindLocationAccessAcquirementScreenDisplayedOnceRepository(
+        locationAccessAcquirementScreenDisplayedOnceRepository: LocationAccessAcquirementScreenDisplayedOnceRepositoryImpl,
+    ): LocationAccessAcquirementScreenDisplayedOnceRepository
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:theme="@style/Theme.Interscheckin"
         android:name=".MainApplication"
         android:localeConfig="@xml/locales_config"
+        android:enableOnBackInvokedCallback="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/pub/yusuke/interscheckin/MainActivity.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import pub.yusuke.interscheckin.navigation.InterscheckinNavHost
@@ -14,7 +13,6 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        requestLocationPermission()
         setContent {
             val navController = rememberNavController()
 
@@ -24,30 +22,5 @@ class MainActivity : ComponentActivity() {
             )
         }
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-    }
-
-    private fun requestLocationPermission() {
-        val locationPermissionRequest = registerForActivityResult(
-            ActivityResultContracts.RequestMultiplePermissions(),
-        ) { permissions ->
-            when {
-                permissions.getOrDefault(
-                    android.Manifest.permission.ACCESS_FINE_LOCATION,
-                    false,
-                ) && permissions.getOrDefault(
-                    android.Manifest.permission.ACCESS_COARSE_LOCATION,
-                    false,
-                ) -> {
-                }
-                else -> {
-                }
-            }
-        }
-        locationPermissionRequest.launch(
-            arrayOf(
-                android.Manifest.permission.ACCESS_FINE_LOCATION,
-                android.Manifest.permission.ACCESS_COARSE_LOCATION,
-            ),
-        )
     }
 }

--- a/app/src/main/java/pub/yusuke/interscheckin/MainApplicationModule.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/MainApplicationModule.kt
@@ -25,6 +25,8 @@ import pub.yusuke.interscheckin.repositories.foursquarecheckins.FoursquareChecki
 import pub.yusuke.interscheckin.repositories.foursquarecheckins.FoursquareCheckinsRepositoryImpl
 import pub.yusuke.interscheckin.repositories.foursquarecheckins.FoursquarePlacesRepository
 import pub.yusuke.interscheckin.repositories.foursquarecheckins.FoursquarePlacesRepositoryImpl
+import pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce.LocationAccessAcquirementScreenDisplayedOnceRepository
+import pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce.LocationAccessAcquirementScreenDisplayedOnceRepositoryImpl
 import pub.yusuke.interscheckin.repositories.settings.SettingsPreferences
 import pub.yusuke.interscheckin.repositories.settings.SettingsPreferencesSerializer
 import pub.yusuke.interscheckin.repositories.settings.SettingsRepository
@@ -80,14 +82,6 @@ class MainApplicationModule {
         foursquareClient: FoursquareClient,
     ): FoursquarePlacesRepository {
         return FoursquarePlacesRepositoryImpl(foursquareClient)
-    }
-
-    companion object {
-        private const val KEYSET_NAME = "master_keyset"
-        private const val PREFERENCE_FILE = "master_key_preference"
-        private const val MASTER_KEY_URI = "android-keystore://master_key"
-
-        private const val DATASTORE_FILE = "settings.pb"
     }
 
     @Singleton
@@ -156,4 +150,19 @@ class MainApplicationModule {
     fun provideVisitedVenueDao(
         appDatabase: AppDatabase,
     ) = appDatabase.visitedVenueDao()
+
+    @Singleton
+    @Provides
+    fun provideLocationAccessAcquirementScreenDisplayedOnceRepository(
+        locationAccessAcquirementScreenDisplayedOnceRepository: LocationAccessAcquirementScreenDisplayedOnceRepositoryImpl,
+    ): LocationAccessAcquirementScreenDisplayedOnceRepository =
+        locationAccessAcquirementScreenDisplayedOnceRepository
+
+    companion object {
+        private const val KEYSET_NAME = "master_keyset"
+        private const val PREFERENCE_FILE = "master_key_preference"
+        private const val MASTER_KEY_URI = "android-keystore://master_key"
+
+        private const val DATASTORE_FILE = "settings.pb"
+    }
 }

--- a/app/src/main/java/pub/yusuke/interscheckin/navigation/InterscheckinNavHost.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/navigation/InterscheckinNavHost.kt
@@ -12,7 +12,7 @@ fun InterscheckinNavHost(
 ) {
     NavHost(
         navController = navController,
-        startDestination = InterscheckinScreens.Main.name,
+        startDestination = InterscheckinScreens.Splash.route,
     ) {
         InterscheckinNavigations(
             navController = navController,

--- a/app/src/main/java/pub/yusuke/interscheckin/navigation/InterscheckinNavigations.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/navigation/InterscheckinNavigations.kt
@@ -7,8 +7,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import pub.yusuke.interscheckin.MainActivity
 import pub.yusuke.interscheckin.ui.histories.HistoriesScreen
+import pub.yusuke.interscheckin.ui.locationaccessacquirement.LocationAccessAcquirementScreen
 import pub.yusuke.interscheckin.ui.main.MainScreen
 import pub.yusuke.interscheckin.ui.settings.SettingsScreen
+import pub.yusuke.interscheckin.ui.splash.SplashScreen
 
 // Composable な関数の中で Composable な関数っぽく呼び出されているので Supress
 @Suppress("FunctionNaming")
@@ -16,6 +18,14 @@ fun NavGraphBuilder.InterscheckinNavigations(
     navController: NavController,
     activity: Activity,
 ) {
+    composable(InterscheckinScreens.Splash.route) {
+        SplashScreen(navController = navController)
+    }
+
+    composable(InterscheckinScreens.LocationAccessAcquirement.route) {
+        LocationAccessAcquirementScreen(navController = navController)
+    }
+
     composable(InterscheckinScreens.Main.route) {
         MainScreen(
             navController = navController,

--- a/app/src/main/java/pub/yusuke/interscheckin/navigation/InterscheckinScreens.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/navigation/InterscheckinScreens.kt
@@ -8,6 +8,9 @@ sealed class InterscheckinScreens(
 ) {
     val route: String = name.withArguments(navArguments)
 
+    object Splash : InterscheckinScreens("splash")
+    object LocationAccessAcquirement : InterscheckinScreens("locationAccessAcquirement")
+
     // / Screen for creating checkin
     object Main : InterscheckinScreens("main")
     object Settings : InterscheckinScreens("settings")

--- a/app/src/main/java/pub/yusuke/interscheckin/repositories/locationaccessacquirementscreendisplayedonce/LocationAccessAcquirementScreenDisplayedOnceRepository.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/repositories/locationaccessacquirementscreendisplayedonce/LocationAccessAcquirementScreenDisplayedOnceRepository.kt
@@ -1,0 +1,5 @@
+package pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce
+
+interface LocationAccessAcquirementScreenDisplayedOnceRepository {
+    var locationAccessAcquirementScreenDisplayedOnce: Boolean
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/repositories/locationaccessacquirementscreendisplayedonce/LocationAccessAcquirementScreenDisplayedOnceRepositoryImpl.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/repositories/locationaccessacquirementscreendisplayedonce/LocationAccessAcquirementScreenDisplayedOnceRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce
+
+import android.content.Context
+import androidx.core.content.edit
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class LocationAccessAcquirementScreenDisplayedOnceRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : LocationAccessAcquirementScreenDisplayedOnceRepository {
+    private val preferences = context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+
+    override var locationAccessAcquirementScreenDisplayedOnce: Boolean
+        get() = preferences.getBoolean(KEY_LOCATION_ACCESS_ACQUIREMENT_SCREEN_DISPLAYED_ONCE, false)
+        set(value) {
+            preferences.edit {
+                putBoolean(KEY_LOCATION_ACCESS_ACQUIREMENT_SCREEN_DISPLAYED_ONCE, value)
+            }
+        }
+
+    companion object {
+        const val FILE_NAME = "location_access_acquirement_screen_displayed_once"
+        private const val KEY_LOCATION_ACCESS_ACQUIREMENT_SCREEN_DISPLAYED_ONCE =
+            "locationAccessAcquirementScreenDisplayedOnce"
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementContract.kt
@@ -1,0 +1,43 @@
+package pub.yusuke.interscheckin.ui.locationaccessacquirement
+
+interface LocationAccessAcquirementContract {
+    interface ViewModel {
+        fun onScreenRendered()
+    }
+
+    interface Interactor {
+        fun setLocationAccessAcquirementScreenDisplayed()
+    }
+
+    sealed interface ScreenState {
+        /**
+         * この画面に遷移してきてから位置情報へのアクセスの可能性などを調査しており表示すべき画面が未だ定まらないとき
+         */
+        object Loading : ScreenState
+
+        /**
+         * 位置情報へのアクセスが一切不可能だがダイアログを表示できるとき（初回起動時は基本的にこれになる）
+         */
+        object NoLocationAccessAcquired : ScreenState
+
+        /**
+         * 大まかな位置情報へのアクセスのみができ、かつダイアログを表示できるとき
+         */
+        object OnlyCoarseLocationAccessAcquired : ScreenState
+
+        /**
+         * 詳細な位置情報へのアクセスができるとき
+         */
+        object PreciseLocationAccessAcquired : ScreenState
+
+        /**
+         * 大まかな位置情報へのアクセスのみができ、かつダイアログを表示できないとき
+         */
+        object PreciseLocationAccessNotAcquirable : ScreenState
+
+        /**
+         * 位置情報へのアクセスが一切不可能かつダイアログを表示できないとき
+         */
+        object LocationAccessNotAcquirable : ScreenState
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementInteractor.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementInteractor.kt
@@ -1,0 +1,13 @@
+package pub.yusuke.interscheckin.ui.locationaccessacquirement
+
+import pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce.LocationAccessAcquirementScreenDisplayedOnceRepository
+import javax.inject.Inject
+
+class LocationAccessAcquirementInteractor @Inject constructor(
+    private val locationAccessAcquirementScreenDisplayedOnceRepository: LocationAccessAcquirementScreenDisplayedOnceRepository,
+) : LocationAccessAcquirementContract.Interactor {
+    override fun setLocationAccessAcquirementScreenDisplayed() {
+        locationAccessAcquirementScreenDisplayedOnceRepository
+            .locationAccessAcquirementScreenDisplayedOnce = true
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementModule.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementModule.kt
@@ -1,0 +1,13 @@
+package pub.yusuke.interscheckin.ui.locationaccessacquirement
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+interface LocationAccessAcquirementModule {
+    @Binds
+    fun bindInteractor(interactor: LocationAccessAcquirementInteractor): LocationAccessAcquirementContract.Interactor
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementScreen.kt
@@ -1,0 +1,365 @@
+package pub.yusuke.interscheckin.ui.locationaccessacquirement
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import pub.yusuke.interscheckin.R
+import pub.yusuke.interscheckin.navigation.InterscheckinScreens
+import pub.yusuke.interscheckin.ui.theme.InterscheckinPrimaryButton
+import pub.yusuke.interscheckin.ui.theme.InterscheckinSecondaryButton
+import pub.yusuke.interscheckin.ui.theme.InterscheckinTextStyle
+import pub.yusuke.interscheckin.ui.theme.InterscheckinTheme
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun LocationAccessAcquirementScreen(
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    viewModel: LocationAccessAcquirementContract.ViewModel = hiltViewModel<LocationAccessAcquirementViewModel>(),
+) {
+    val context = LocalContext.current
+    val activity = context.findActivity()
+
+    var screenState: LocationAccessAcquirementContract.ScreenState by remember {
+        mutableStateOf(
+            LocationAccessAcquirementContract.ScreenState.Loading,
+        )
+    }
+    val locationPermissionState = rememberMultiplePermissionsState(
+        permissions = listOf(
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ),
+    ) {
+        screenState = computeScreenState(
+            it.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false),
+            it.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false),
+            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_COARSE_LOCATION),
+            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION),
+        )
+    }
+    val locationAccessAcquired = locationPermissionState
+        .permissions
+        .any {
+            it.permission == Manifest.permission.ACCESS_COARSE_LOCATION &&
+                it.status == PermissionStatus.Granted
+        }
+    val preciseLocationAccessAcquired = locationPermissionState
+        .allPermissionsGranted
+    val shouldShowRationaleForPreciseLocationAcquirement =
+        ActivityCompat.shouldShowRequestPermissionRationale(
+            activity,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        )
+    val shouldShowRationaleForLocationAcquirement =
+        ActivityCompat.shouldShowRequestPermissionRationale(
+            activity,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+        )
+
+    screenState = computeScreenState(
+        locationAccessAcquired,
+        preciseLocationAccessAcquired,
+        shouldShowRationaleForLocationAcquirement,
+        shouldShowRationaleForPreciseLocationAcquirement,
+    )
+
+    InterscheckinTheme {
+        Surface(
+            modifier = modifier,
+        ) {
+            when (screenState) {
+                LocationAccessAcquirementContract.ScreenState.Loading ->
+                    LoadingContent()
+
+                LocationAccessAcquirementContract.ScreenState.NoLocationAccessAcquired ->
+                    NoLocationAccessAcquiredContent(
+                        onAffirmativeRequest = {
+                            locationPermissionState.launchMultiplePermissionRequest()
+                        },
+                        onNegativeRequest = { navController.jumpToMain() },
+                    )
+
+                LocationAccessAcquirementContract.ScreenState.OnlyCoarseLocationAccessAcquired ->
+                    OnlyCoarseLocationAccessAcquiredContent(
+                        onAffirmativeRequest = {
+                            locationPermissionState.launchMultiplePermissionRequest()
+                        },
+                        onNegativeRequest = { navController.jumpToMain() },
+                    )
+
+                LocationAccessAcquirementContract.ScreenState.PreciseLocationAccessAcquired ->
+                    PreciseLocationAccessAcquiredContent(
+                        onAffirmativeRequest = { navController.jumpToMain() },
+                    )
+
+                LocationAccessAcquirementContract.ScreenState.LocationAccessNotAcquirable ->
+                    LocationAccessNotAcquirableContent(
+                        onAffirmativeRequest = { openApplicationDetailsSettings(context) },
+                        onNegativeRequest = { navController.jumpToMain() },
+                    )
+
+                LocationAccessAcquirementContract.ScreenState.PreciseLocationAccessNotAcquirable ->
+                    PreciseLocationAccessNotAcquirableContent(
+                        onAffirmativeRequest = { openApplicationDetailsSettings(context) },
+                        onNegativeRequest = { navController.jumpToMain() },
+                    )
+            }
+        }
+    }
+
+    viewModel.onScreenRendered()
+}
+
+private fun computeScreenState(
+    locationAccessAcquired: Boolean,
+    preciseLocationAccessAcquired: Boolean,
+    shouldShowRationaleForLocationAcquirement: Boolean,
+    shouldShowRationaleForPreciseLocationAcquirement: Boolean,
+): LocationAccessAcquirementContract.ScreenState {
+    return when {
+        !locationAccessAcquired && shouldShowRationaleForLocationAcquirement ->
+            LocationAccessAcquirementContract.ScreenState.NoLocationAccessAcquired
+
+        !preciseLocationAccessAcquired && shouldShowRationaleForPreciseLocationAcquirement ->
+            LocationAccessAcquirementContract.ScreenState.OnlyCoarseLocationAccessAcquired
+
+        preciseLocationAccessAcquired ->
+            LocationAccessAcquirementContract.ScreenState.PreciseLocationAccessAcquired
+
+        !locationAccessAcquired ->
+            LocationAccessAcquirementContract.ScreenState.LocationAccessNotAcquirable
+
+        else ->
+            LocationAccessAcquirementContract.ScreenState.PreciseLocationAccessNotAcquirable
+    }
+}
+
+/**
+ * Should be unreachable
+ */
+@Composable
+private fun LoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun NoLocationAccessAcquiredContent(
+    onAffirmativeRequest: () -> Unit,
+    onNegativeRequest: () -> Unit,
+) {
+    TwoChoicesContent(
+        title = stringResource(R.string.location_access_acquirement_no_location_access_acquired_content_title),
+        description = stringResource(R.string.location_access_acquirement_no_location_access_acquired_content_description),
+        affirmativeActionText = stringResource(R.string.location_access_acquirement_no_location_access_acquired_content_allow),
+        negativeActionText = stringResource(R.string.location_access_acquirement_no_location_access_acquired_content_deny),
+        onAffirmativeRequest = onAffirmativeRequest,
+        onNegativeRequest = onNegativeRequest,
+    )
+}
+
+@Composable
+private fun OnlyCoarseLocationAccessAcquiredContent(
+    onAffirmativeRequest: () -> Unit,
+    onNegativeRequest: () -> Unit,
+) {
+    TwoChoicesContent(
+        title = stringResource(R.string.location_access_acquirement_only_coarse_location_access_acquired_content_title),
+        description = stringResource(R.string.location_access_acquirement_only_coarse_location_access_acquired_content_description),
+        affirmativeActionText = stringResource(R.string.location_access_acquirement_only_coarse_location_access_acquired_content_allow),
+        negativeActionText = stringResource(R.string.location_access_acquirement_only_coarse_location_access_acquired_content_deny),
+        onAffirmativeRequest = onAffirmativeRequest,
+        onNegativeRequest = onNegativeRequest,
+    )
+}
+
+@Composable
+private fun PreciseLocationAccessAcquiredContent(
+    onAffirmativeRequest: () -> Unit,
+) {
+    TwoChoicesContent(
+        title = stringResource(R.string.location_access_acquirement_precise_location_access_acquired_content_title),
+        description = stringResource(R.string.location_access_acquirement_precise_location_access_acquired_content_description),
+        affirmativeActionText = stringResource(R.string.location_access_acquirement_precise_location_access_acquired_content_close),
+        negativeActionText = null,
+        onAffirmativeRequest = onAffirmativeRequest,
+        onNegativeRequest = null,
+    )
+}
+
+@Composable
+private fun PreciseLocationAccessNotAcquirableContent(
+    onAffirmativeRequest: () -> Unit,
+    onNegativeRequest: () -> Unit,
+) {
+    TwoChoicesContent(
+        title = stringResource(R.string.location_access_acquirement_precise_location_access_not_acquirable_content_title),
+        description = stringResource(R.string.location_access_acquirement_precise_location_access_not_acquirable_content_description),
+        affirmativeActionText = stringResource(R.string.location_access_acquirement_precise_location_access_not_acquirable_content_settings),
+        negativeActionText = stringResource(R.string.location_access_acquirement_precise_location_access_not_acquirable_content_close),
+        onAffirmativeRequest = onAffirmativeRequest,
+        onNegativeRequest = onNegativeRequest,
+    )
+}
+
+@Composable
+private fun LocationAccessNotAcquirableContent(
+    onAffirmativeRequest: () -> Unit,
+    onNegativeRequest: () -> Unit,
+) {
+    TwoChoicesContent(
+        title = stringResource(R.string.location_access_acquirement_location_access_not_acquirable_content_title),
+        description = stringResource(R.string.location_access_acquirement_location_access_not_acquirable_content_description),
+        affirmativeActionText = stringResource(R.string.location_access_acquirement_location_access_not_acquirable_content_settings),
+        negativeActionText = stringResource(R.string.location_access_acquirement_location_access_not_acquirable_content_close),
+        onAffirmativeRequest = onAffirmativeRequest,
+        onNegativeRequest = onNegativeRequest,
+    )
+}
+
+@Composable
+private fun TwoChoicesContent(
+    title: String,
+    description: String,
+    affirmativeActionText: String?,
+    negativeActionText: String?,
+    onAffirmativeRequest: (() -> Unit)?,
+    onNegativeRequest: (() -> Unit)?,
+    modifier: Modifier = Modifier
+        .fillMaxSize()
+        .padding(16.dp),
+) {
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = title,
+                style = InterscheckinTextStyle.SuperExtraLarge,
+            )
+            Divider()
+            Text(
+                text = description,
+                style = InterscheckinTextStyle.Normal,
+            )
+        }
+        Row(
+            horizontalArrangement = twoSidesArrangement(
+                startVisible = onAffirmativeRequest != null,
+                endVisible = onNegativeRequest != null,
+            ),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth(),
+        ) {
+            onNegativeRequest?.let {
+                InterscheckinSecondaryButton(
+                    text = requireNotNull(negativeActionText),
+                    onClick = it,
+                )
+            }
+
+            onAffirmativeRequest?.let {
+                InterscheckinPrimaryButton(
+                    text = requireNotNull(affirmativeActionText),
+                    onClick = it,
+                )
+            }
+        }
+    }
+}
+
+private fun twoSidesArrangement(
+    startVisible: Boolean,
+    endVisible: Boolean,
+) =
+    if (startVisible) {
+        if (endVisible) {
+            Arrangement.SpaceBetween
+        } else {
+            Arrangement.Start
+        }
+    } else {
+        Arrangement.End
+    }
+
+private fun NavController.jumpToMain() {
+    navigate(InterscheckinScreens.Main.route) {
+        popUpTo(InterscheckinScreens.LocationAccessAcquirement.route) {
+            inclusive = true
+        }
+    }
+}
+
+private fun openApplicationDetailsSettings(
+    context: Context,
+) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+    }
+    context.startActivity(intent)
+}
+
+private fun Context.findActivity(): Activity {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    error("Couldn't find Activity from the given context")
+}
+
+@Preview
+@Composable
+private fun PreviewTwoChoicesContent() {
+    TwoChoicesContent(
+        title = "test",
+        description = "this is a test",
+        affirmativeActionText = "Submit",
+        negativeActionText = "Dismiss",
+        onAffirmativeRequest = {},
+        onNegativeRequest = {},
+    )
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementViewModel.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementViewModel.kt
@@ -1,0 +1,14 @@
+package pub.yusuke.interscheckin.ui.locationaccessacquirement
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class LocationAccessAcquirementViewModel @Inject constructor(
+    private val interactor: LocationAccessAcquirementContract.Interactor,
+) : ViewModel(), LocationAccessAcquirementContract.ViewModel {
+    override fun onScreenRendered() {
+        interactor.setLocationAccessAcquirementScreenDisplayed()
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import pub.yusuke.interscheckin.R
+import pub.yusuke.interscheckin.navigation.InterscheckinScreens
 import pub.yusuke.interscheckin.ui.theme.InterscheckinTheme
 import pub.yusuke.interscheckin.ui.utils.copy
 
@@ -98,6 +99,13 @@ fun SettingsScreen(
                     },
                 ) {
                     Text(stringResource(R.string.settings_reset_cached_venues))
+                }
+                Button(
+                    onClick = {
+                        navController.navigate(InterscheckinScreens.LocationAccessAcquirement.route)
+                    },
+                ) {
+                    Text(stringResource(R.string.settings_enable_location_access))
                 }
             }
         }

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashContract.kt
@@ -1,0 +1,16 @@
+package pub.yusuke.interscheckin.ui.splash
+
+import kotlinx.coroutines.flow.StateFlow
+import pub.yusuke.interscheckin.navigation.InterscheckinScreens
+
+interface SplashContract {
+    interface ViewModel {
+        val nextInterscheckinScreenStateFlow: StateFlow<InterscheckinScreens?>
+
+        fun onNavigatedToAnotherScreen()
+    }
+
+    interface Interactor {
+        fun locationAccessAcquirementScreenAlreadyNavigatedTo(): Boolean
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashInteractor.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashInteractor.kt
@@ -1,0 +1,11 @@
+package pub.yusuke.interscheckin.ui.splash
+
+import pub.yusuke.interscheckin.repositories.locationaccessacquirementscreendisplayedonce.LocationAccessAcquirementScreenDisplayedOnceRepository
+import javax.inject.Inject
+
+class SplashInteractor @Inject constructor(
+    private val locationAccessAcquirementScreenDisplayedOnceRepository: LocationAccessAcquirementScreenDisplayedOnceRepository,
+) : SplashContract.Interactor {
+    override fun locationAccessAcquirementScreenAlreadyNavigatedTo() =
+        locationAccessAcquirementScreenDisplayedOnceRepository.locationAccessAcquirementScreenDisplayedOnce
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashModule.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashModule.kt
@@ -1,0 +1,13 @@
+package pub.yusuke.interscheckin.ui.splash
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+interface SplashModule {
+    @Binds
+    fun bindInteractor(interactor: SplashInteractor): SplashContract.Interactor
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashScreen.kt
@@ -1,0 +1,51 @@
+package pub.yusuke.interscheckin.ui.splash
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import pub.yusuke.interscheckin.R
+import pub.yusuke.interscheckin.navigation.InterscheckinScreens
+import pub.yusuke.interscheckin.ui.theme.InterscheckinTextStyle
+import pub.yusuke.interscheckin.ui.theme.InterscheckinTheme
+
+@Composable
+fun SplashScreen(
+    navController: NavController,
+    modifier: Modifier = Modifier.fillMaxSize(),
+    viewModel: SplashContract.ViewModel = hiltViewModel<SplashViewModel>(),
+) {
+    val nextInterscheckinScreen by viewModel.nextInterscheckinScreenStateFlow.collectAsState()
+
+    nextInterscheckinScreen?.let {
+        navController.navigate(it.route) {
+            popUpTo(InterscheckinScreens.Splash.route) {
+                inclusive = true
+            }
+        }
+        viewModel.onNavigatedToAnotherScreen()
+    }
+
+    InterscheckinTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier,
+        ) {
+            Text(
+                text = stringResource(R.string.splash_interscheckin_title),
+                style = InterscheckinTextStyle.SuperExtraLarge,
+            )
+            Text(
+                text = stringResource(R.string.splash_interscheckin_loading),
+                style = InterscheckinTextStyle.Normal,
+            )
+        }
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/splash/SplashViewModel.kt
@@ -1,0 +1,35 @@
+package pub.yusuke.interscheckin.ui.splash
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import pub.yusuke.interscheckin.navigation.InterscheckinScreens
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val interactor: SplashInteractor,
+) : ViewModel(), SplashContract.ViewModel {
+    private val _nextInterscheckinScreenStateFlow: MutableStateFlow<InterscheckinScreens?> =
+        MutableStateFlow(null)
+    override val nextInterscheckinScreenStateFlow: StateFlow<InterscheckinScreens?> =
+        _nextInterscheckinScreenStateFlow
+
+    override fun onNavigatedToAnotherScreen() {
+        _nextInterscheckinScreenStateFlow.value = null
+    }
+
+    init {
+        fetchContents()
+    }
+
+    private fun fetchContents() {
+        _nextInterscheckinScreenStateFlow.value =
+            if (interactor.locationAccessAcquirementScreenAlreadyNavigatedTo()) {
+                InterscheckinScreens.Main
+            } else {
+                InterscheckinScreens.LocationAccessAcquirement
+            }
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/theme/InterscheckinButton.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/theme/InterscheckinButton.kt
@@ -1,0 +1,55 @@
+package pub.yusuke.interscheckin.ui.theme
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import pub.yusuke.interscheckin.ui.theme.InterscheckinTextStyle.bold
+
+@Composable
+fun InterscheckinPrimaryButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier,
+        contentPadding = PaddingValues(12.dp),
+    ) {
+        Text(
+            text = text,
+            style = InterscheckinTextStyle.Normal.bold(),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+fun InterscheckinSecondaryButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    TextButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier,
+        contentPadding = PaddingValues(12.dp),
+    ) {
+        Text(
+            text = text,
+            style = InterscheckinTextStyle.Normal.bold(),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/theme/InterscheckinTextStyle.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/theme/InterscheckinTextStyle.kt
@@ -1,0 +1,15 @@
+package pub.yusuke.interscheckin.ui.theme
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+object InterscheckinTextStyle {
+    val Small = TextStyle(fontSize = 10.sp)
+    val Normal = TextStyle(fontSize = 12.sp)
+    val Large = TextStyle(fontSize = 14.sp)
+    val ExtraLarge = TextStyle(fontSize = 16.sp)
+    val SuperExtraLarge = TextStyle(fontSize = 30.sp)
+
+    fun TextStyle.bold() = this.copy(fontWeight = FontWeight.Bold)
+}

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2,6 +2,17 @@
 <resources>
     <string name="app_name">Interscheckin</string>
     <string name="main_driving_mode_checkbox_label">運転モード</string>
+    <string name="splash_interscheckin_title">Interscheckin</string>
+    <string name="location_access_acquirement_no_location_access_acquired_content_title">位置情報へのアクセスを有効化する</string>
+    <string name="location_access_acquirement_no_location_access_acquired_content_description">このアプリは venue の検索とチェックインの作成のために位置情報を利用します。アクセス許可が無い場合、チェックイン履歴の閲覧だけができます。</string>
+    <string name="location_access_acquirement_no_location_access_acquired_content_allow">許可</string>
+    <string name="location_access_acquirement_no_location_access_acquired_content_deny">拒否</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_title">正確な位置情報へのアクセスを許可する</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_description">正確な位置情報へのアクセスが許可されると Interscheckin の全体的な体験が十分に良くなるでしょう。</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_allow">許可</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_deny">拒否</string>
+    <string name="location_access_acquirement_precise_location_access_acquired_content_title">正確な位置情報へのアクセスが既に可能です</string>
+    <string name="location_access_acquirement_precise_location_access_acquired_content_description">すでに Interscheckin にあなたの正確な位置情報の取得を許可しています。やった〜！</string>
     <string name="main_request_venue_list_update">情報更新</string>
     <string name="main_unexpected_error_happened">予期しないエラーが発生しました：%1$s</string>
     <string name="settings_topbar_title">設定</string>
@@ -25,4 +36,15 @@
     <string name="main_button_histories">履歴一覧</string>
     <string name="histories_no_histories_found">履歴はありません</string>
     <string name="main_settings">設定</string>
+    <string name="location_access_acquirement_precise_location_access_acquired_content_close">閉じる</string>
+    <string name="settings_enable_location_access">位置情報へのアクセスを許可</string>
+    <string name="splash_interscheckin_loading">読み込み中……</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_title">詳細な位置情報は利用できません</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_description">詳細な位置情報へのアクセスが拒否されています。許可するためには設定を開いてください。</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_settings">設定</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_close">閉じる</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_title">位置情報は利用できません</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_description">位置情報へのアクセスが拒否されました。許可するためには設定を開いてください。</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_settings">設定</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_close">閉じる</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,31 @@
 <resources>
     <string name="app_name">Interscheckin</string>
 
+    <!-- SplashScreen -->
+    <string name="splash_interscheckin_title">Interscheckin</string>
+    <string name="splash_interscheckin_loading">Loading…</string>
+
+    <!-- LocationAccessAcquirementScreen -->
+    <string name="location_access_acquirement_no_location_access_acquired_content_title">Enable location access</string>
+    <string name="location_access_acquirement_no_location_access_acquired_content_description">This app uses locations for searching venues and creating checkins.\nWithout the access, you can only access to the histories of your checkins.</string>
+    <string name="location_access_acquirement_no_location_access_acquired_content_allow">Allow</string>
+    <string name="location_access_acquirement_no_location_access_acquired_content_deny">Deny</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_title">Allow access to precise location</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_description">The overall experience of Interscheckin would be sufficiently nice if you give this app the access to your precise location.</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_allow">Allow</string>
+    <string name="location_access_acquirement_only_coarse_location_access_acquired_content_deny">Deny</string>
+    <string name="location_access_acquirement_precise_location_access_acquired_content_title">Access already acquired to precise locations</string>
+    <string name="location_access_acquirement_precise_location_access_acquired_content_description">You\'ve already allowed Interscheckin to access to your precise locations. Hooray!</string>
+    <string name="location_access_acquirement_precise_location_access_acquired_content_close">close</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_title">Precise location is unavailable</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_description">You\'ve chosen not to display a dialog for precise location request anymore.\nTo enable precise location access, go to App settings.</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_settings">Settings</string>
+    <string name="location_access_acquirement_precise_location_access_not_acquirable_content_close">close</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_title">Location access is unavailable</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_description">You\'ve chosen not to display a dialog for location access anymore.\nTo enable location access, go to App settings.</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_settings">Settings</string>
+    <string name="location_access_acquirement_location_access_not_acquirable_content_close">close</string>
+
     <!-- MainScreen -->
     <string name="main_request_venue_list_update">Update Venue list</string>
     <string name="main_go_to_settings_button_label">Settings</string>
@@ -26,6 +51,7 @@
     <string name="settings_reason_credentials_not_set">Please set credentials first to use Interscheckin.</string>
     <string name="settings_reason_invalid_credentials">Invalid credentials.\nConsider generating new OAuth token, or check typos.</string>
     <string name="settings_reset_cached_venues">Reset cached venues</string>
+    <string name="settings_enable_location_access">Enable location access</string>
 
     <!-- HistoriesScreen -->
     <string name="histories_topbar_title">Histories</string>


### PR DESCRIPTION
# 概要

対象 Issue: #96

位置情報取得導線画面（`LocationAccessAcquirementScreen`）を追加します。
また、`MainScreen` とこれを出し分けるための画面 `SplashScreen` を追加します。

後続 PR で `SettingsScreen` 内にある `LocationAccessAcquirementScreen` への導線のボタンの enabled の制御および `MainScreen` で位置情報が利用不可能な際に Snackbar を出すための実装を追加する予定です。

| 初回起動時 | すべて拒否 | 粗い位置情報の許可 | 詳細な位置情報の拒否 | 詳細な位置情報の許可 |
| - | - | - | - | - |
| <img width="200" src="https://user-images.githubusercontent.com/30387586/227581851-e3f5249c-b797-45c1-ba4a-313b8751d123.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227581859-7ba8805e-8e0e-4920-b623-58975cacf781.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227581863-97e6f31b-93da-4b12-be15-4250d7fff879.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227581864-ecccd59f-74a9-418f-86ab-e1528183371e.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227581869-8a34f662-5dd6-446b-950c-0fb4496c0fa6.png"> |

