### PR TITLE
Disable `LocationAccessAcquirementScreenButton` in `SettingsScreen` when location access has already been acquired

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/locationaccessacquirement/LocationAccessAcquirementScreen.kt
@@ -33,14 +33,15 @@ import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.PermissionStatus
-import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import pub.yusuke.interscheckin.R
 import pub.yusuke.interscheckin.navigation.InterscheckinScreens
 import pub.yusuke.interscheckin.ui.theme.InterscheckinPrimaryButton
 import pub.yusuke.interscheckin.ui.theme.InterscheckinSecondaryButton
 import pub.yusuke.interscheckin.ui.theme.InterscheckinTextStyle
 import pub.yusuke.interscheckin.ui.theme.InterscheckinTheme
+import pub.yusuke.interscheckin.ui.utils.locationAccessAcquired
+import pub.yusuke.interscheckin.ui.utils.preciseLocationAccessAcquired
+import pub.yusuke.interscheckin.ui.utils.rememberLocationAccessAcquirementState
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -57,12 +58,7 @@ fun LocationAccessAcquirementScreen(
             LocationAccessAcquirementContract.ScreenState.Loading,
         )
     }
-    val locationPermissionState = rememberMultiplePermissionsState(
-        permissions = listOf(
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-        ),
-    ) {
+    val locationPermissionState = rememberLocationAccessAcquirementState {
         screenState = computeScreenState(
             it.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false),
             it.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false),
@@ -71,13 +67,9 @@ fun LocationAccessAcquirementScreen(
         )
     }
     val locationAccessAcquired = locationPermissionState
-        .permissions
-        .any {
-            it.permission == Manifest.permission.ACCESS_COARSE_LOCATION &&
-                it.status == PermissionStatus.Granted
-        }
+        .locationAccessAcquired()
     val preciseLocationAccessAcquired = locationPermissionState
-        .allPermissionsGranted
+        .preciseLocationAccessAcquired()
     val shouldShowRationaleForPreciseLocationAcquirement =
         ActivityCompat.shouldShowRequestPermissionRationale(
             activity,

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/utils/MultiplePermissionsStateUtils.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/utils/MultiplePermissionsStateUtils.kt
@@ -1,0 +1,37 @@
+package pub.yusuke.interscheckin.ui.utils
+
+import android.Manifest
+import androidx.compose.runtime.Composable
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+
+@ExperimentalPermissionsApi
+@Composable
+fun rememberLocationAccessAcquirementState(
+    onPermissionsResult: (Map<String, Boolean>) -> Unit = {},
+) =
+    rememberMultiplePermissionsState(
+        permissions = listOf(
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ),
+        onPermissionsResult = onPermissionsResult,
+    )
+
+@ExperimentalPermissionsApi
+fun MultiplePermissionsState.locationAccessAcquired() =
+    permissions
+        .any {
+            it.permission == Manifest.permission.ACCESS_COARSE_LOCATION &&
+                it.status == PermissionStatus.Granted
+        }
+
+@ExperimentalPermissionsApi
+fun MultiplePermissionsState.preciseLocationAccessAcquired() =
+    permissions
+        .any {
+            it.permission == Manifest.permission.ACCESS_FINE_LOCATION &&
+                it.status == PermissionStatus.Granted
+        }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -47,4 +47,7 @@
     <string name="location_access_acquirement_location_access_not_acquirable_content_description">位置情報へのアクセスが拒否されました。許可するためには設定を開いてください。</string>
     <string name="location_access_acquirement_location_access_not_acquirable_content_settings">設定</string>
     <string name="location_access_acquirement_location_access_not_acquirable_content_close">閉じる</string>
+    <string name="settings_location_access_already_acquired">位置情報へのアクセスがすでに可能</string>
+    <string name="settings_acquire_precise_location_access">正確な位置情報へのアクセスを許可</string>
+    <string name="settings_acquire_location_access">位置情報へのアクセスを許可</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,9 @@
     <string name="settings_reason_invalid_credentials">Invalid credentials.\nConsider generating new OAuth token, or check typos.</string>
     <string name="settings_reset_cached_venues">Reset cached venues</string>
     <string name="settings_enable_location_access">Enable location access</string>
+    <string name="settings_location_access_already_acquired">Location access already acquired</string>
+    <string name="settings_acquire_precise_location_access">Acquire precise location access</string>
+    <string name="settings_acquire_location_access">Acquire location access</string>
 
     <!-- HistoriesScreen -->
     <string name="histories_topbar_title">Histories</string>


### PR DESCRIPTION
# 概要

関連 Issue: #96 

`SettingsScreen` にある `LocationAccessAcquirementScreen` に遷移するためのボタンの文言および enabled が現在の位置情報取得権限に基づいて変わるようにします。

また、Accompanist が提供する `rememberMultiplePermissionsState` と `MultiplePermissionsState` をより位置情報の取得で簡素に利用するために `MultiplePermissionsStateUtils.kt` に幾つかの拡張関数を定義します。

## スクリーンショット

| 位置情報が取得できないとき | 詳細な位置情報が取得できないとき | 詳細な位置情報が取得できるとき |
| :-: | :-: | :-: |
| <img width="200" src="https://user-images.githubusercontent.com/30387586/227678068-0931083a-30da-4ad0-b2e7-67da1bba1558.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227678070-e25d6262-c3c8-49bd-9aa8-c81fae4b52dc.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227678072-ee341075-5423-45c9-bf34-e7c5d25d1d7e.png"> |

