### PR TITLE
Show Snackbar when location access is not available in `MainScreen`

### DIFF
--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/FakeMainViewModelModule.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/FakeMainViewModelModule.kt
@@ -4,7 +4,6 @@ import android.os.VibratorManager
 import androidx.compose.runtime.mutableStateOf
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -22,10 +21,20 @@ import pub.yusuke.interscheckin.ui.main.util.MainScreenTestData
     replaces = [MainViewModelModule::class],
 )
 interface FakeMainViewModelModule {
-    @Binds
-    fun bindInteractor(interactor: MainInteractor): MainContract.Interactor
-
     companion object {
+        @Provides
+        fun provideInteractor(
+            mainInteractor: MainInteractor
+        ): MainContract.Interactor {
+            val interactor = spyk(mainInteractor)
+
+            // Assume that the access to precise locations is available
+            every { interactor.locationProvidersAvailable() } returns true
+            every { interactor.preciseLocationAccessAvailable() } returns true
+
+            return interactor
+        }
+
         @Provides
         fun provideViewModel(
             interactor: MainContract.Interactor,

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainContract.kt
@@ -43,6 +43,8 @@ interface MainContract {
             latitude: Double,
             longitude: Double,
         ): Checkin
+        fun locationProvidersAvailable(): Boolean
+        fun preciseLocationAccessAvailable(): Boolean
 
         fun vibrate(vibrationEffect: VibrationEffect)
     }
@@ -73,6 +75,7 @@ interface MainContract {
         class Loading(val lastLocation: Location? = null) : LocationState()
         class Loaded(val location: Location) : LocationState()
         class Error(val throwable: Throwable) : LocationState()
+        object Unavailable : LocationState()
     }
 
     sealed class VenuesState {
@@ -96,6 +99,8 @@ interface MainContract {
         object SkipUpdatingVenueList : SnackbarState
         object InvalidCredentials : SnackbarState
         object CredentialsNotSet : SnackbarState
+        object LocationProvidersNotAvailable : SnackbarState
+        object PreciseLocationNotAvailable : SnackbarState
         data class UnexpectedError(val throwable: Throwable) : SnackbarState
     }
 }

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
@@ -1,10 +1,16 @@
 package pub.yusuke.interscheckin.ui.main
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import android.location.Location
+import android.location.LocationManager
 import android.os.VibrationEffect
 import android.os.VibratorManager
 import androidx.annotation.FloatRange
+import androidx.core.content.ContextCompat
 import com.google.android.gms.location.FusedLocationProviderClient
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import pub.yusuke.foursquareclient.models.Checkin
@@ -26,6 +32,7 @@ class MainInteractor @Inject constructor(
     private val vibratorManager: VibratorManager,
     private val fusedLocationProviderClient: FusedLocationProviderClient,
     private val visitedVenueDao: VisitedVenueDao,
+    @ApplicationContext private val context: Context,
 ) : MainContract.Interactor {
     override suspend fun fetchVenues(
         latitude: Double,
@@ -75,6 +82,18 @@ class MainInteractor @Inject constructor(
         latitude = latitude,
         longitude = longitude,
     ).translateToMainContractCheckin()
+
+    override fun locationProvidersAvailable(): Boolean =
+        (context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager)
+            ?.let { locationManager ->
+                locationManager.getProviders(true).size > 0
+            } ?: false
+
+    override fun preciseLocationAccessAvailable(): Boolean =
+        (
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED
+            )
 
     override fun vibrate(vibrationEffect: VibrationEffect) =
         vibratorManager.defaultVibrator.vibrate(vibrationEffect)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -50,4 +50,9 @@
     <string name="settings_location_access_already_acquired">位置情報へのアクセスがすでに可能</string>
     <string name="settings_acquire_precise_location_access">正確な位置情報へのアクセスを許可</string>
     <string name="settings_acquire_location_access">位置情報へのアクセスを許可</string>
+    <string name="main_snackbar_location_providers_not_available_action">設定</string>
+    <string name="main_snackbar_location_providers_not_available_message">位置情報が利用できません</string>
+    <string name="main_snackbar_precise_location_not_available_action">設定</string>
+    <string name="main_snackbar_precise_location_not_available_message">正確な位置情報を取得できません。お望みの venue が見つからない可能性があります</string>
+    <string name="main_location_unavailable">位置情報が利用できません</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="main_go_to_settings_button_label">Settings</string>
     <string name="main_location_loading">Retrieving location…</string>
     <string name="main_location_loaded">You are at %1$s (± %2$s m)</string>
+    <string name="main_location_unavailable">Location unavailable</string>
     <string name="main_shout_placeholder">What are you up to?</string>
     <string name="main_button_checkin">Check-in</string>
     <string name="main_driving_mode_checkbox_label">driving mode</string>
@@ -42,6 +43,10 @@
     <string name="main_button_histories">Histories</string>
     <string name="main_unexpected_error_happened">An unexpected error happened: %1$s</string>
     <string name="main_settings">settings</string>
+    <string name="main_snackbar_location_providers_not_available_message">Location access is not available</string>
+    <string name="main_snackbar_location_providers_not_available_action">settings</string>
+    <string name="main_snackbar_precise_location_not_available_message">Precise location access is not available. The venue you want may not be found</string>
+    <string name="main_snackbar_precise_location_not_available_action">settings</string>
 
     <!-- SettingsScreen -->
     <string name="settings_topbar_title">Settings</string>


### PR DESCRIPTION
# 概要

closes #96 

位置情報の取得が許可されていないとき、または詳細な位置情報の取得が許可されていないときに `MainScreen` でその旨および位置情報取得導線画面に遷移するための Snackbar を表示するようにします。

| 位置情報が取得できないとき | 詳細な位置情報が取得できないとき | 詳細な位置情報が取得できるとき |
| :-: | :-: | :-: |
| <img width="200" src="https://user-images.githubusercontent.com/30387586/227681357-c30746aa-6a12-4942-aaa5-2793ce4dcad2.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227681362-b899ee35-f319-40f6-abe3-b670d0088b12.png"> | <img width="200" src="https://user-images.githubusercontent.com/30387586/227681366-0b8f2325-20e6-48b7-8e6c-a14dd74546f8.png"> |
