### PR TITLE
Prevent sending unnecessary `Authoriization` header with v2 endpoints

### DIFF
--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/FoursquareClientImpl.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/FoursquareClientImpl.kt
@@ -193,7 +193,6 @@ class FoursquareClientImpl(
             broadcast = broadcast,
             ll = ll,
             oauthToken = oauthToken,
-            authorization = apiKey,
         ).response.checkin
     }.fold(
         onSuccess = { it },
@@ -219,7 +218,6 @@ class FoursquareClientImpl(
             limit = limit,
             beforeTimestamp = beforeTimestamp,
             oauthToken = oauthToken,
-            authorization = apiKey,
         ).response.checkins.items
     }.fold(
         onSuccess = { it },

--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/network/CheckinApiService.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/network/CheckinApiService.kt
@@ -2,7 +2,6 @@ package pub.yusuke.foursquareclient.network
 
 import pub.yusuke.foursquareclient.models.Checkin
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -26,8 +25,6 @@ interface CheckinApiService {
         broadcast: String?,
         @Query("v")
         v: String? = "20221002",
-        @Header("Authorization")
-        authorization: String,
     ): CreateCheckinResponse
 
     data class CreateCheckinResponse(
@@ -59,8 +56,6 @@ interface CheckinApiService {
         oauthToken: String,
         @Query("v")
         v: String? = "20221002",
-        @Header("Authorization")
-        authorization: String,
     ): GetCheckinHistoriesResponse
 
     data class GetCheckinHistoriesResponse(


### PR DESCRIPTION
# 概要

Foursquare の API エンドポイントである `/v2/checkins/add` と `/v2/users/{userId}/historysearch` を利用する際に不要な `Authorization` ヘッダーおよびその値を指定したリクエストを送信しているのを解消します。