### PR TITLE
Remove unnecessary package version exclusion for automerging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,6 @@
     },
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true


### PR DESCRIPTION
# 概要

ref: https://github.com/private-yusuke/interscheckin/pull/118#issuecomment-1495338163

0 からはじまるバージョン番号を持つパッケージに対しては Renovate による automerging が無効になっていたのをやめ、有効にします。