### PR TITLE
Aggregate Kotlin and `composeOptions` updates in the same PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "groupName": "kotlin"
     },
     {
-      "matchPackagePatterns": ["androidx.compose.compiler:compiler"],
+      "matchPackagePatterns": ["composeOptions"],
       "groupName": "kotlin"
     },
     {


### PR DESCRIPTION
# 概要

#85 で導入した Renovate の設定によって Kotlin と Compose Compiler のアップデートが単一の PR にまとめて実施されるようになることを期待していたが別々の PR が作られてしまった（#117 と #125）ので、これを修正します。