### PR TITLE
Increase the interval between periodic location updates

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/navigation/entity/PeriodicLocationRetrievalIntervalPreset.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/navigation/entity/PeriodicLocationRetrievalIntervalPreset.kt
@@ -5,17 +5,17 @@ sealed interface PeriodicLocationRetrievalIntervalPreset {
 
     object High : PeriodicLocationRetrievalIntervalPreset {
         override val interval: Long
-            get() = 1
+            get() = 10
     }
 
     object Medium : PeriodicLocationRetrievalIntervalPreset {
         override val interval: Long
-            get() = 3
+            get() = 15
     }
 
     object Low : PeriodicLocationRetrievalIntervalPreset {
         override val interval: Long
-            get() = 10
+            get() = 30
     }
 }
 


### PR DESCRIPTION
# 概要

#closes 130

定期的な位置情報の更新頻度が思っていたよりも高すぎて、実際に利用した際には「低（10 秒毎）」しか利用しなかったので、これを「高」として扱うようにし、他のプリセットでの頻度も合わせて落とすようにします。