### PR TITLE
Turn on the screen just before the instrumented test starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
+    - name: Build APK for instrumented tests
+      run: ./gradlew packageDebugAndroidTest
     - name: Wake up the device
       run: adb shell input keyevent KEYCODE_MENU
     - name: Run instrumented tests with the physical device connected


### PR DESCRIPTION
# 概要

instrumented test を実行する端末の画面を、その実行の直前にオンにするようにします。

今までは画面をオンにしてから instrumented test のための APK をビルドしていましたが、これには時間がかかっていました。今回の変更によって事前に APK のビルドをしておくことにより、画面がオンになってからテストが走るまでの間の時間を短くすることができ、端末の自動ロックまでの時間を短くすることができたり、画面が光ってからテストが走るまで待つ時間が短くなることで暇なときに走るのを見たくなったときの人間の待ち時間が短くなったりすることが期待できます。