### PR TITLE
Prevent depending on `VibratorManager` directly

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "pub.yusuke.interscheckin"
-        minSdk = 32
+        minSdk = 26
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreenTest.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/histories/HistoriesScreenTest.kt
@@ -47,7 +47,7 @@ class HistoriesScreenTest {
     }
 
     @Test
-    fun `A check-in with a venue is displayed on the screen`() {
+    fun `A_Check-in_with_a_venue_is_displayed_on_the_screen`() {
         composeTestRule.setContent {
             HistoriesScreen(
                 viewModel = vm,
@@ -61,7 +61,7 @@ class HistoriesScreenTest {
     }
 
     @Test
-    fun `Display _No Histories Found_ when no check-in history is found`() {
+    fun `Display__No_Histories_Found__when_no_check-in_history_is_found`() {
         // given (that no histories are available)
         every { vm.checkinsFlow } returns flowOf(
             PagingData.empty(

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/FakeMainViewModelModule.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/FakeMainViewModelModule.kt
@@ -1,6 +1,6 @@
 package pub.yusuke.interscheckin.ui.main
 
-import android.os.VibratorManager
+import android.os.Vibrator
 import androidx.compose.runtime.mutableStateOf
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
@@ -49,12 +49,7 @@ interface FakeMainViewModelModule {
         }
 
         @Provides
-        fun provideVibratorManager(): VibratorManager {
-            val vibratorManager: VibratorManager = mockk()
-            every { vibratorManager.defaultVibrator } returns mockk(relaxUnitFun = true)
-
-            return vibratorManager
-        }
+        fun provideVibrator(): Vibrator = mockk(relaxUnitFun = true)
 
         @Provides
         fun provideFusedLocationProviderClient(): FusedLocationProviderClient {

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/MainScreenTest.kt
@@ -1,6 +1,6 @@
 package pub.yusuke.interscheckin.ui.main
 
-import android.os.VibratorManager
+import android.os.Build
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertIsEnabled
@@ -23,6 +23,7 @@ import io.mockk.junit4.MockKRule
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.junit.After
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -56,6 +57,11 @@ class MainScreenTest {
      */
     @Before
     fun init() {
+        /*
+         * io.mockk.proxy.MockKAgentException: Mocking static is supported starting from Android P
+         */
+        Assume.assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+
         /*
          * To mock `suspend fun FusedLocationProviderClient.currentLocation()`,
          * calling `mockkStatic` is required.

--- a/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/pub/yusuke/interscheckin/ui/main/MainScreenTest.kt
@@ -49,9 +49,6 @@ class MainScreenTest {
     lateinit var navController: NavController
 
     @Inject
-    lateinit var vibratorManager: VibratorManager
-
-    @Inject
     lateinit var fusedLocationProviderClient: FusedLocationProviderClient
 
     /**

--- a/app/src/main/java/pub/yusuke/interscheckin/MainApplicationModule.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/MainApplicationModule.kt
@@ -2,7 +2,8 @@ package pub.yusuke.interscheckin
 
 import android.app.Application
 import android.content.Context
-import android.os.VibratorManager
+import android.os.Vibrator
+import androidx.core.content.getSystemService
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.room.RoomDatabase
@@ -115,9 +116,9 @@ class MainApplicationModule {
     }
 
     @Provides
-    fun provideVibratorManager(
+    fun provideVibrator(
         @ApplicationContext context: Context,
-    ) = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+    ): Vibrator = requireNotNull(context.getSystemService())
 
     @Provides
     fun provideFusedLocationProviderClient(

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesViewModel.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/histories/HistoriesViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 @HiltViewModel
-class HistoriesViewModel @Inject constructor(
+open class HistoriesViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     paging: HistoriesContract.Paging,
 ) : ViewModel(), HistoriesContract.ViewModel {

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/main/MainInteractor.kt
@@ -6,7 +6,7 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
 import android.os.VibrationEffect
-import android.os.VibratorManager
+import android.os.Vibrator
 import androidx.annotation.FloatRange
 import androidx.core.content.ContextCompat
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -33,7 +33,7 @@ class MainInteractor @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val foursquarePlacesRepository: FoursquarePlacesRepository,
     private val foursquareCheckinsRepository: FoursquareCheckinsRepository,
-    private val vibratorManager: VibratorManager,
+    private val vibrator: Vibrator,
     private val fusedLocationProviderClient: FusedLocationProviderClient,
     private val visitedVenueDao: VisitedVenueDao,
     private val periodicLocationRetrievalRepository: PeriodicLocationRetrievalRepository,
@@ -108,7 +108,7 @@ class MainInteractor @Inject constructor(
         periodicLocationRetrievalRepository.periodicLocationRetrievalPreferencesFlow
 
     override fun vibrate(vibrationEffect: VibrationEffect) =
-        vibratorManager.defaultVibrator.vibrate(vibrationEffect)
+        vibrator.vibrate(vibrationEffect)
 
     private fun List<Venue>.translateToMainContractVenues(): List<MainContract.Venue> =
         map { it.translateToMainContractVenue() }

--- a/library/foursquare-client/build.gradle.kts
+++ b/library/foursquare-client/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 32
+        minSdk = 26
         targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/library/fusedlocationktx/build.gradle.kts
+++ b/library/fusedlocationktx/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 32
+        minSdk = 26
         targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
# 概要

closes #147

`VibratorManager` は API Level 31 以降で提供されているクラスであるが、インスタンスを得るためには Context が必要であり、これは `Vibrator` を取得するときも同様である。また、haptic な feedback をこのアプリで加えたい訳でもない。したがって、要求される API Level を 31 に上げてまで `VibratorManager` を利用する意味はない。

そこで、Interactor の実装では `Vibrator` を受け取るようにし、`VibratorManager` の注入にかかわっていた箇所はすべて `Vibrator` に変更します。これによって `minSdk` を 26 にまで落とすことができます。