### PR TITLE
Set `Geocodes.main` as optional

### DIFF
--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Venue.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Venue.kt
@@ -29,7 +29,7 @@ data class Chain(
 )
 
 data class Geocodes(
-    val main: LatAndLong,
+    val main: LatAndLong?,
 //    val roof: Roof?
 )
 


### PR DESCRIPTION
# 概要

たまに `com.squareup.moshi.JsonDataException: Required value 'main' missing at $.results[18].geocodes` のような例外が発生することがあるため、API サーバから返却されるフィールドの実態に合わせて `Geocodes.main` を optional にします。