### PR TITLE
Bump up kotlin to 2.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.plugin.serialization)
     alias(libs.plugins.ksp)
@@ -47,9 +48,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
     }
     packaging {
         resources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.dependency.analysis)
+    alias(libs.plugins.compose.compiler) apply false
 }
 // see https://detekt.dev/docs/introduction/reporting/#merging-reports
 val reportMerge by tasks.registering(ReportMergeTask::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ detekt = "1.23.6"
 espressoCore = "3.6.1"
 hilt = "2.51.1"
 junit = "4.13.2"
-kotlin = "1.9.24"
+kotlin = "2.0.0"
 mockk = "1.13.12"
 paging = "3.3.1"
 playServicesLocation = "21.3.0"
@@ -69,9 +69,10 @@ androidx-wear-compose-material = { group = "androidx.wear.compose", name = "comp
 [plugins]
 android-application = { id = "com.android.application", version = "8.5.1" }
 android-library = { id = "com.android.library", version = "8.5.1" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-ksp = { id = "com.google.devtools.ksp", version = "1.9.24-1.0.20" }
+ksp = { id = "com.google.devtools.ksp", version = "2.0.0-1.0.23" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version = "1.33.0" }

--- a/renovate.json
+++ b/renovate.json
@@ -9,10 +9,6 @@
       "groupName": "kotlin"
     },
     {
-      "matchPackagePatterns": ["composeOptions"],
-      "groupName": "kotlin"
-    },
-    {
       "matchPackagePatterns": ["com.google.devtools.ksp"],
       "groupName": "kotlin"
     },

--- a/watchapp/build.gradle.kts
+++ b/watchapp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -37,9 +38,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
     }
     packaging {
         resources {


### PR DESCRIPTION
# 概要

related: #332, #339

Kotlin 2.0.0 を利用するようにします。