### PR TITLE
Add landscape layout for `MainScreen`

### DIFF
--- a/app/src/main/java/pub/yusuke/interscheckin/ui/credentialsettings/CredentialSettingsScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/credentialsettings/CredentialSettingsScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -20,6 +22,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -51,6 +54,26 @@ fun CredentialSettingsScreen(
                 InterscheckinTopBar(
                     titleText = stringResource(R.string.credential_settings_topbar_title),
                     onClickNavigationIcon = { navController.popBackStack() },
+                    actions = {
+                        Button(
+                            onClick = {
+                                coroutineScope.launch {
+                                    viewModel.saveSettings(
+                                        foursquareOAuthToken = foursquareOAuthToken,
+                                        foursquareApiKey = foursquareApiKey,
+                                    )
+                                    onRecreateRequired()
+                                }
+                            },
+                            enabled = foursquareApiKey.isNotBlank() && foursquareOAuthToken.isNotBlank(),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Color.Transparent,
+                                contentColor = MaterialTheme.colorScheme.primary,
+                            ),
+                        ) {
+                            Text(stringResource(R.string.credential_settings_save))
+                        }
+                    },
                 )
             },
             modifier = modifier,
@@ -72,20 +95,6 @@ fun CredentialSettingsScreen(
                     value = foursquareApiKey,
                     onValueChange = { foursquareApiKey = it },
                 )
-                Button(
-                    onClick = {
-                        coroutineScope.launch {
-                            viewModel.saveSettings(
-                                foursquareOAuthToken = foursquareOAuthToken,
-                                foursquareApiKey = foursquareApiKey,
-                            )
-                            onRecreateRequired()
-                        }
-                    },
-                    enabled = foursquareApiKey.isNotBlank() && foursquareOAuthToken.isNotBlank(),
-                ) {
-                    Text(stringResource(R.string.credential_settings_save))
-                }
             }
         }
     }

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/credentialsettings/CredentialSettingsScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/credentialsettings/CredentialSettingsScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -57,7 +59,8 @@ fun CredentialSettingsScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier
-                    .padding(innerPadding),
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
             ) {
                 CredentialSettingRow(
                     label = stringResource(R.string.credential_settings_foursquare_oauth_token_label),

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/locationsettings/LocationSettingsScreen.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/locationsettings/LocationSettingsScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LocalContentColor
@@ -66,7 +68,8 @@ fun LocationSettingsScreen(
                             start = 16.dp,
                             end = 16.dp,
                         ),
-                    ),
+                    )
+                    .verticalScroll(rememberScrollState()),
             ) {
                 when (val it = screenState) {
                     LocationSettingsContract.ScreenState.Loading -> CircularProgressIndicator()

--- a/app/src/main/java/pub/yusuke/interscheckin/ui/utils/TopAppBarComponents.kt
+++ b/app/src/main/java/pub/yusuke/interscheckin/ui/utils/TopAppBarComponents.kt
@@ -1,5 +1,6 @@
 package pub.yusuke.interscheckin.ui.utils
 
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,6 +20,7 @@ fun InterscheckinTopBar(
     modifier: Modifier = Modifier,
     navigationIcon: ImageVector = Icons.Filled.ArrowBack,
     navigationIconDescription: String = "backIcon",
+    actions: @Composable RowScope.() -> Unit = {},
 ) {
     TopAppBar(
         title = { Text(titleText) },
@@ -28,5 +30,6 @@ fun InterscheckinTopBar(
             }
         },
         modifier = modifier,
+        actions = actions,
     )
 }


### PR DESCRIPTION
# 概要

closes #408

画面が横倒しになっているときに `MainScreen`, `CredentialSettingsScreen` そして `LocationSettingsScreen` の一部のボタンが画面外に描画され押下できない問題を解決します。

## スクリーンショット

| 画面の名前 | 変更前 | 変更後 |
| - | - | - |
| メイン画面 | <img src="https://github.com/user-attachments/assets/9722098a-4a7b-4d9d-bd43-ac1dc0d3762c" width="300"> | <img src="https://github.com/user-attachments/assets/22584b74-80a9-47c9-8d69-3f10526f3351" width="300"> |
| 認証情報入力画面 | <img src="https://github.com/user-attachments/assets/19403992-4d05-4f9a-ba99-5f8b068534db" width="300"> | <img src="https://github.com/user-attachments/assets/fe4807d4-bcb6-49d3-aa3d-1324d0846874" width="300"> |
| 位置情報設定画面 | <img src="https://github.com/user-attachments/assets/0482608f-5a7c-4ad1-a617-b05902386559" width="300"> | <img src="https://github.com/user-attachments/assets/e6030855-29d3-4c0f-86ae-5eeb3768fd6c" width="300"> |

`MainScreen` については、変更後の画面右側は垂直方向にスクロールできるようになっているため、縦画面で見えていたボタンが押下できるようになっています。
また、縦画面でも Venue 一覧以外のコントロール部分が垂直方向にスクロールできるようになっているため、画面サイズが小さい端末で同様の問題が生じていた場合にはそれが副次的に解決されます。

他の 2 つの画面では、単に垂直方向のスクロールをできるようにしました。
ただし、`CredentialSettingsScreen` では、画面最下部に配置されていた保存用のボタンを画面上部右側に移動しました。これは、画面の最下部までユーザがスクロールしなければ保存ボタンの存在に気づかないという問題があったためです。