### PR TITLE
Migrate nearby places lookup API to geotagging candidates API

### DIFF
--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/FoursquareClientImpl.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/FoursquareClientImpl.kt
@@ -4,9 +4,14 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import pub.yusuke.foursquareclient.models.Category
+import pub.yusuke.foursquareclient.models.Chain
 import pub.yusuke.foursquareclient.models.Checkin
+import pub.yusuke.foursquareclient.models.Geocodes
 import pub.yusuke.foursquareclient.models.LatAndLong
+import pub.yusuke.foursquareclient.models.Location
 import pub.yusuke.foursquareclient.models.Venue
+import pub.yusuke.foursquareclient.models.distanceFrom
 import pub.yusuke.foursquareclient.models.llString
 import pub.yusuke.foursquareclient.network.CheckinApiService
 import pub.yusuke.foursquareclient.network.VenueApiService
@@ -25,6 +30,7 @@ class FoursquareClientImpl(
 
     private val interceptor = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY
+        redactHeader("Authorization")
     }
 
     private val client = OkHttpClient.Builder()
@@ -84,16 +90,18 @@ class FoursquareClientImpl(
         limit: Int?,
     ): List<Venue> =
         runCatching {
-            if (apiKey.isBlank()) {
-                throw EmptyAPIKeyException("Foursquare API key is blank.")
+            if (oauthToken.isBlank()) {
+                throw EmptyOAuthTokenException("Foursquare OAuth token is blank.")
             }
             venueApiService.searchPlacesNearby(
                 ll = ll.llString(),
                 hacc = hacc,
                 query = query,
                 limit = limit,
-                authorization = apiKey,
-            ).results
+                authorization = "Bearer $oauthToken",
+            ).candidates.map { candidate ->
+                candidate.toVenue(ll)
+            }
         }.fold(
             onSuccess = { it },
             onFailure = {
@@ -233,4 +241,44 @@ class FoursquareClientImpl(
 
     class EmptyOAuthTokenException(message: String) : Exception(message)
     class EmptyAPIKeyException(message: String) : Exception(message)
+
+    private fun VenueApiService.GeotaggingCandidate.toVenue(origin: LatAndLong): Venue {
+        val coordinates = latitude?.let { latitude ->
+            longitude?.let { longitude -> LatAndLong(latitude, longitude) }
+        }
+        return Venue(
+            categories = categories.map { category ->
+                Category(
+                    id = category.fsqCategoryId,
+                    icon = category.icon,
+                    name = category.name,
+                )
+            },
+            chains = chains?.map { chain ->
+                Chain(
+                    id = chain.fsqChainId,
+                    name = chain.name,
+                )
+            },
+            distance = coordinates?.distanceFrom(origin),
+            fsqId = fsqPlaceId,
+            geocodes = Geocodes(main = coordinates),
+            link = link,
+            location = Location(
+                address = location?.address,
+                addressExtended = null,
+                censusBlock = null,
+                country = location?.country.orEmpty(),
+                crossStreet = null,
+                dma = null,
+                formattedAddress = location?.formattedAddress,
+                locality = location?.locality,
+                postcode = location?.postcode,
+                region = location?.region,
+            ),
+            name = name,
+            relatedPlaces = null,
+            timezone = null,
+        )
+    }
 }

--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Venue.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/models/Venue.kt
@@ -1,6 +1,11 @@
 package pub.yusuke.foursquareclient.models
 
 import com.squareup.moshi.Json
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.roundToLong
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 data class Venue(
     val categories: List<Category>,
@@ -60,9 +65,24 @@ data class Location(
 data class LatAndLong(
     val latitude: Double,
     val longitude: Double,
-)
+) {
+    companion object {
+        const val EARTH_RADIUS_METERS = 6_371_000.0
+    }
+}
 
 fun LatAndLong.llString() = "${latitude.toBigDecimal().toPlainString()},${longitude.toBigDecimal().toPlainString()}"
+fun LatAndLong.distanceFrom(other: LatAndLong): Long {
+    val latitudeDelta = Math.toRadians(latitude - other.latitude)
+    val longitudeDelta = Math.toRadians(longitude - other.longitude)
+    val startLatitude = Math.toRadians(other.latitude)
+    val endLatitude = Math.toRadians(latitude)
+    val haversine =
+        sin(latitudeDelta / 2) * sin(latitudeDelta / 2) +
+            cos(startLatitude) * cos(endLatitude) *
+            sin(longitudeDelta / 2) * sin(longitudeDelta / 2)
+    return (LatAndLong.EARTH_RADIUS_METERS * 2 * asin(sqrt(haversine))).roundToLong()
+}
 
 data class Parent(
     @Json(name = "fsq_id")

--- a/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/network/VenueApiService.kt
+++ b/library/foursquare-client/src/main/java/pub/yusuke/foursquareclient/network/VenueApiService.kt
@@ -1,5 +1,7 @@
 package pub.yusuke.foursquareclient.network
 
+import com.squareup.moshi.Json
+import pub.yusuke.foursquareclient.models.Icon
 import pub.yusuke.foursquareclient.models.Venue
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -34,9 +36,9 @@ interface VenueApiService {
     )
 
     /**
-     * https://developer.foursquare.com/reference/places-nearby
+     * https://docs.foursquare.com/fsq-developers-places/reference/geotagging-candidates
      */
-    @GET("/v3/places/nearby")
+    @GET("https://places-api.foursquare.com/geotagging/candidates")
     @Headers("Accept: application/json")
     suspend fun searchPlacesNearby(
         @Query("ll")
@@ -47,12 +49,51 @@ interface VenueApiService {
         query: String? = null,
         @Query("limit")
         limit: Int? = null,
+        @Query("fields")
+        fields: String = GEOTAGGING_CANDIDATE_FIELDS,
+        @Header("X-Places-Api-Version")
+        apiVersion: String = PLACES_API_VERSION,
         @Header("Authorization")
         authorization: String,
     ): SearchPlacesNearbyResponse
 
     data class SearchPlacesNearbyResponse(
-        val results: List<Venue>,
+        val candidates: List<GeotaggingCandidate>,
+    )
+
+    data class GeotaggingCandidate(
+        val categories: List<GeotaggingCandidateCategory>,
+        val chains: List<GeotaggingCandidateChain>?,
+        @Json(name = "fsq_place_id")
+        val fsqPlaceId: String,
+        val latitude: Double?,
+        val longitude: Double?,
+        val link: String?,
+        val location: GeotaggingCandidateLocation?,
+        val name: String,
+    )
+
+    data class GeotaggingCandidateCategory(
+        @Json(name = "fsq_category_id")
+        val fsqCategoryId: String,
+        val icon: Icon,
+        val name: String,
+    )
+
+    data class GeotaggingCandidateChain(
+        @Json(name = "fsq_chain_id")
+        val fsqChainId: String,
+        val name: String,
+    )
+
+    data class GeotaggingCandidateLocation(
+        val address: String? = null,
+        val country: String? = null,
+        @Json(name = "formatted_address")
+        val formattedAddress: String? = null,
+        val locality: String? = null,
+        val postcode: String? = null,
+        val region: String? = null,
     )
 
     /**
@@ -119,4 +160,10 @@ interface VenueApiService {
         val type: String,
         val place: Venue?,
     )
+
+    companion object {
+        const val PLACES_API_VERSION = "2025-06-17"
+        const val GEOTAGGING_CANDIDATE_FIELDS =
+            "fsq_place_id,name,categories,chains,latitude,longitude,link,location"
+    }
 }

--- a/library/foursquare-client/src/test/java/pub/yusuke/foursquareclient/network/GeotaggingCandidatesResponseTest.kt
+++ b/library/foursquare-client/src/test/java/pub/yusuke/foursquareclient/network/GeotaggingCandidatesResponseTest.kt
@@ -1,0 +1,54 @@
+package pub.yusuke.foursquareclient.network
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class GeotaggingCandidatesResponseTest {
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(VenueApiService.SearchPlacesNearbyResponse::class.java)
+
+    @Test
+    fun parsesCurrentGeotaggingCandidatesResponse() {
+        val response = adapter.fromJson(
+            """
+            {
+              "candidates": [{
+                "fsq_place_id": "4dd0d870c65bdac7139b6d88",
+                "latitude": 36.10657,
+                "longitude": 140.10553,
+                "categories": [{
+                  "fsq_category_id": "52f2ab2ebcbc57f1066b8b4f",
+                  "name": "Bus Stop",
+                  "icon": {
+                    "prefix": "https://example.com/bus_",
+                    "suffix": ".png"
+                  }
+                }],
+                "chains": [{
+                  "fsq_chain_id": "556f676fbd6a75a99038d8e9",
+                  "name": "7-Eleven"
+                }],
+                "link": "/places/4dd0d870c65bdac7139b6d88",
+                "location": {
+                  "country": "JP",
+                  "formatted_address": "つくば市, 茨城県"
+                },
+                "name": "天久保三丁目バス停"
+              }]
+            }
+            """.trimIndent(),
+        )
+
+        assertNotNull(response)
+        val candidate = response!!.candidates.single()
+        assertEquals("4dd0d870c65bdac7139b6d88", candidate.fsqPlaceId)
+        assertEquals("52f2ab2ebcbc57f1066b8b4f", candidate.categories.single().fsqCategoryId)
+        assertEquals("556f676fbd6a75a99038d8e9", candidate.chains?.single()?.fsqChainId)
+        assertEquals("つくば市, 茨城県", candidate.location?.formattedAddress)
+    }
+}


### PR DESCRIPTION
Foursquare が提供する API のうち `/v3/places/nearby` が廃止されていたため、地点一覧が取得できなくなっていた。
そのため、https://docs.foursquare.com/fsq-developers-places/reference/geotagging-candidates に移行する。